### PR TITLE
fix: migrate to hatchling build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,11 @@ Changelog = "https://github.com/eoleedi/TimeTree-exporter/blob/main/CHANGELOG.md
 timetree-exporter = "timetree_exporter.__main__:main"
 
 [build-system]
-requires = ["uv_build>=0.9.17,<0.10.0"]
-build-backend = "uv_build"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.sdist]
+exclude = ["/tests", "*.json", "uv.lock", "CHANGELOG.md"]
 
 [tool.uv.build-backend]
 module-name = "timetree_exporter"


### PR DESCRIPTION
migrate to hatchling build-system as uv-build doesn't support modifying the source_date_epoch, causing the build process to fail.
<img width="1499" height="483" alt="Screenshot 2026-02-16 at 12 33 14" src="https://github.com/user-attachments/assets/1dfd924e-dc46-476d-971a-54275a6faa1c" />
