### PR TITLE
fix: bound exported timezone definitions

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,16 @@
 """Tests for CLI entry helpers in __main__."""
 
-from timetree_exporter.__main__ import label_suffix_for_group, list_labels_and_exit
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from timetree_exporter.__main__ import (
+    create_calendar,
+    label_suffix_for_group,
+    list_labels_and_exit,
+    write_calendar,
+)
+from timetree_exporter.event import TimeTreeEvent
+from timetree_exporter.formatter import ICalEventFormatter
 
 
 class _FakeCalendarApi:
@@ -36,3 +46,24 @@ def test_label_suffix_for_group_sanitizes_label_name():
     labels = {3: {"name": "Work / Home", "color": "#ff00aa"}}
 
     assert label_suffix_for_group(3, labels) == "Work___Home"
+
+
+def test_write_calendar_adds_bounded_vtimezone_before_events(tmp_path, normal_event_data):
+    """Bounded VTIMEZONE components should be written before VEVENT blocks."""
+    data = normal_event_data.copy()
+    taipei_time = datetime(2024, 8, 14, 9, 30, tzinfo=ZoneInfo("Asia/Taipei"))
+    data["start_at"] = int(taipei_time.timestamp() * 1000)
+    data["end_at"] = int((taipei_time + timedelta(hours=1)).timestamp() * 1000)
+
+    cal = create_calendar()
+    cal.add_component(ICalEventFormatter(TimeTreeEvent.from_dict(data)).to_ical())
+    output_path = tmp_path / "calendar.ics"
+
+    write_calendar(cal, output_path)
+    serialized = output_path.read_text(encoding="utf-8")
+
+    assert "DTSTART;TZID=Asia/Taipei:20240814T093000" in serialized
+    assert "BEGIN:VTIMEZONE" in serialized
+    assert "TZID:Asia/Taipei" in serialized
+    assert "TZOFFSETTO:+0800" in serialized
+    assert serialized.index("BEGIN:VTIMEZONE") < serialized.index("BEGIN:VEVENT")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,18 @@
 """Tests for the utils module."""
 
 import tempfile
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
+from timetree_exporter.__main__ import create_calendar
+from timetree_exporter.event import TimeTreeEvent
+from timetree_exporter.formatter import ICalEventFormatter
 from timetree_exporter.utils import (
+    add_bounded_timezones_before_events,
     convert_timestamp_to_datetime,
     get_events_from_file,
+    get_timezone_date_ranges,
     paths_to_filelist,
 )
 
@@ -125,3 +130,48 @@ def test_convert_timestamp_to_datetime():
     assert tokyo_dt.month == 1
     assert tokyo_dt.day == 1
     assert tokyo_dt.hour == 9  # 東京比UTC快9小時
+
+
+def test_get_timezone_date_ranges(normal_event_data):
+    """Test collecting bounded date ranges for each referenced TZID."""
+    data = normal_event_data.copy()
+    taipei_time = datetime(2024, 8, 14, 9, 30, tzinfo=ZoneInfo("Asia/Taipei"))
+    data["start_at"] = int(taipei_time.timestamp() * 1000)
+    data["end_at"] = int((taipei_time + timedelta(hours=1)).timestamp() * 1000)
+
+    cal = create_calendar()
+    cal.add_component(ICalEventFormatter(TimeTreeEvent.from_dict(data)).to_ical())
+
+    assert get_timezone_date_ranges(cal) == {
+        "Asia/Taipei": (taipei_time.date(), taipei_time.date())
+    }
+
+
+def test_add_bounded_timezones_warns_when_blocks_exceed_200_lines(
+    monkeypatch, caplog, normal_event_data
+):
+    """Warn when generated VTIMEZONE blocks may trigger Google Calendar parsing bugs."""
+    data = normal_event_data.copy()
+    data["start_timezone"] = "America/New_York"
+    data["end_timezone"] = "America/New_York"
+    new_york_time = datetime(2024, 8, 14, 9, 30, tzinfo=ZoneInfo("America/New_York"))
+    data["start_at"] = int(new_york_time.timestamp() * 1000)
+    data["end_at"] = int((new_york_time + timedelta(hours=1)).timestamp() * 1000)
+
+    cal = create_calendar()
+    cal.add_component(ICalEventFormatter(TimeTreeEvent.from_dict(data)).to_ical())
+
+    class _LargeTimezone:
+        name = "VTIMEZONE"
+
+        def to_ical(self):
+            return ("BEGIN:VTIMEZONE\n" + "X-LINE:1\n" * 201 + "END:VTIMEZONE\n").encode()
+
+    monkeypatch.setattr(
+        "timetree_exporter.utils.Timezone.from_tzid",
+        lambda *_args, **_kwargs: _LargeTimezone(),
+    )
+
+    add_bounded_timezones_before_events(cal)
+
+    assert "Generated VTIMEZONE blocks contain 203 lines" in caplog.text

--- a/timetree_exporter/__main__.py
+++ b/timetree_exporter/__main__.py
@@ -15,7 +15,7 @@ from icalendar import Calendar
 from timetree_exporter import ICalEventFormatter, TimeTreeEvent, __version__
 from timetree_exporter.api.auth import login
 from timetree_exporter.api.calendar import TimeTreeCalendar
-from timetree_exporter.utils import safe_getpass
+from timetree_exporter.utils import add_bounded_timezones_before_events, safe_getpass
 
 logger = logging.getLogger(__name__)
 package_logger = logging.getLogger(__package__)
@@ -85,9 +85,7 @@ def create_calendar():
 
 def write_calendar(cal, output_path: str):
     """Write a calendar to an .ics file."""
-    # Disable add missing timezones for since it causes issues with Google Calendar. See Issue #157
-    # TODO: Revisit this after bug fixed in Google Calendar
-    # cal.add_missing_timezones()
+    add_bounded_timezones_before_events(cal)
 
     # Transform the output path to a Path object for better handling
     path = Path(output_path)

--- a/timetree_exporter/utils.py
+++ b/timetree_exporter/utils.py
@@ -4,9 +4,11 @@ import getpass
 import inspect
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
+
+from icalendar import Timezone
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +55,69 @@ def convert_timestamp_to_datetime(timestamp, tzinfo=None):
     if timestamp >= 0:
         return datetime.fromtimestamp(timestamp, tzinfo)
     return datetime.fromtimestamp(0, tzinfo) + timedelta(seconds=int(timestamp))
+
+
+def get_timezone_date_ranges(cal):
+    """Return the exported event date range for each referenced TZID."""
+    ranges = {}
+
+    for component in cal.subcomponents:
+        if component.name != "VEVENT":
+            continue
+
+        for property_name in ("dtstart", "dtend"):
+            property_value = component.get(property_name)
+            if property_value is None:
+                continue
+
+            tzid = property_value.params.get("TZID")
+            if not tzid:
+                continue
+
+            datetime_value = property_value.dt
+            event_date = (
+                datetime_value.date() if isinstance(datetime_value, datetime) else datetime_value
+            )
+            if not isinstance(event_date, date):
+                continue
+
+            first_date, last_date = ranges.get(tzid, (event_date, event_date))
+            ranges[tzid] = (min(first_date, event_date), max(last_date, event_date))
+
+    return ranges
+
+
+def add_bounded_timezones_before_events(cal):
+    """Add VTIMEZONE components bounded to the exported event date ranges."""
+    timezone_components = []
+
+    for tzid, (first_date, last_date) in sorted(get_timezone_date_ranges(cal).items()):
+        logger.debug(
+            "Adding VTIMEZONE for TZID=%s with date range %s to %s", tzid, first_date, last_date
+        )
+        try:
+            timezone = Timezone.from_tzid(
+                tzid,
+                first_date=first_date - timedelta(days=1),
+                last_date=last_date + timedelta(days=1),
+            )
+        except ValueError:
+            logger.warning("Skipping unknown timezone: %s", tzid)
+            continue
+
+        timezone_components.append(timezone)
+
+    if timezone_components:
+        timezone_line_count = sum(
+            len(timezone.to_ical().decode("utf-8").splitlines()) for timezone in timezone_components
+        )
+        if timezone_line_count > 200:
+            logger.warning(
+                "Generated VTIMEZONE blocks contain %d lines; Google Calendar may fail to "
+                "import the file correctly or corrupt non-ASCII text",
+                timezone_line_count,
+            )
+        cal.subcomponents = timezone_components + cal.subcomponents
 
 
 def safe_getpass(prompt="Password: ", echo_char=None):


### PR DESCRIPTION
## Summary
- Generate `VTIMEZONE` blocks from actual exported event date ranges instead of the default 1970-2038 range.
- Insert bounded timezone definitions before events so `TZID` references are available to calendar clients.
- Warn when generated timezone blocks exceed 200 lines, matching the Google Calendar parser-risk threshold.

This should mitigate the issue in #157, though it's not fully resolved.
Also fixed an issue where imported events could not be displayed correctly in the Google Calendar mobile app when VTIMEZONE blocks were missing.

## Tests
- `uv run pytest`
- `uv run ruff check timetree_exporter tests`