### PR TITLE
fix: preserve final occurrence for date-only RRULE UNTIL

### DIFF
--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -177,6 +177,27 @@ def test_rrule_until_date_for_timed_event_is_converted_to_utc(normal_event_data)
     ]
 
 
+def test_rrule_until_date_uses_start_timezone(normal_event_data):
+    """Test date-only RRULE UNTIL is interpreted in DTSTART timezone."""
+    data = normal_event_data.copy()
+    data.update(
+        {
+            "recurrences": ["RRULE:FREQ=WEEKLY;UNTIL=20220524"],
+            "start_timezone": "Asia/Tokyo",
+            "end_timezone": "Asia/Taipei",
+            "all_day": False,
+        }
+    )
+
+    event = TimeTreeEvent.from_dict(data)
+    formatter = ICalEventFormatter(event)
+    ical_event = formatter.to_ical()
+
+    assert ical_event["RRULE"]["UNTIL"] == [
+        datetime(2022, 5, 24, 14, 59, 59, tzinfo=ZoneInfo("UTC"))
+    ]
+
+
 def test_rrule_until_date_for_all_day_event_stays_date(normal_event_data):
     """Test all-day date-only RRULE UNTIL remains a date."""
     data = normal_event_data.copy()

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -177,8 +177,8 @@ def test_rrule_until_date_for_timed_event_is_converted_to_utc(normal_event_data)
     ]
 
 
-def test_rrule_until_date_for_all_day_event_is_converted_to_utc(normal_event_data):
-    """Test all-day date-only RRULE UNTIL uses local end-of-day converted to UTC."""
+def test_rrule_until_date_for_all_day_event_stays_date(normal_event_data):
+    """Test all-day date-only RRULE UNTIL remains a date."""
     data = normal_event_data.copy()
     data.update(
         {
@@ -192,9 +192,7 @@ def test_rrule_until_date_for_all_day_event_is_converted_to_utc(normal_event_dat
     formatter = ICalEventFormatter(event)
     ical_event = formatter.to_ical()
 
-    assert ical_event["RRULE"]["UNTIL"] == [
-        datetime(2022, 5, 24, 15, 59, 59, tzinfo=ZoneInfo("UTC"))
-    ]
+    assert ical_event["RRULE"]["UNTIL"] == [date(2022, 5, 24)]
 
 
 def test_no_alarms_location_url(normal_event_data):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -157,6 +157,46 @@ def test_multi_day_all_day_event_dtend_is_exclusive(normal_event_data):
     assert ical_event["dtend"].dt.date() == date(2024, 8, 17)
 
 
+def test_rrule_until_date_for_timed_event_is_converted_to_utc(normal_event_data):
+    """Test date-only RRULE UNTIL uses local end-of-day converted to UTC."""
+    data = normal_event_data.copy()
+    data.update(
+        {
+            "recurrences": ["RRULE:FREQ=WEEKLY;UNTIL=20220524"],
+            "end_timezone": "Asia/Taipei",
+            "all_day": False,
+        }
+    )
+
+    event = TimeTreeEvent.from_dict(data)
+    formatter = ICalEventFormatter(event)
+    ical_event = formatter.to_ical()
+
+    assert ical_event["RRULE"]["UNTIL"] == [
+        datetime(2022, 5, 24, 15, 59, 59, tzinfo=ZoneInfo("UTC"))
+    ]
+
+
+def test_rrule_until_date_for_all_day_event_is_converted_to_utc(normal_event_data):
+    """Test all-day date-only RRULE UNTIL uses local end-of-day converted to UTC."""
+    data = normal_event_data.copy()
+    data.update(
+        {
+            "recurrences": ["RRULE:FREQ=YEARLY;UNTIL=20220524"],
+            "end_timezone": "Asia/Taipei",
+            "all_day": True,
+        }
+    )
+
+    event = TimeTreeEvent.from_dict(data)
+    formatter = ICalEventFormatter(event)
+    ical_event = formatter.to_ical()
+
+    assert ical_event["RRULE"]["UNTIL"] == [
+        datetime(2022, 5, 24, 15, 59, 59, tzinfo=ZoneInfo("UTC"))
+    ]
+
+
 def test_no_alarms_location_url(normal_event_data):
     """Test event formatting without optional fields."""
     # Create an event without alarms, location, and URL

--- a/timetree_exporter/formatter.py
+++ b/timetree_exporter/formatter.py
@@ -4,7 +4,7 @@ for formatting TimeTree events into iCalendar format.
 """
 
 import logging
-from datetime import datetime, timedelta
+from datetime import date, datetime, time, timedelta
 from zoneinfo import ZoneInfo
 
 from icalendar import Alarm, Event, vDate, vDatetime, vGeo, vRecur
@@ -170,7 +170,14 @@ class ICalEventFormatter:
             contentline = Contentline(recurrence)
             name, parameters, value = contentline.parts()
             if name.lower() == "rrule":
-                event.add(name, vRecur.from_ical(value), parameters)
+                recurrence_rule = vRecur.from_ical(value)
+                until = recurrence_rule.get("UNTIL")
+                if until and isinstance(until[0], date) and not isinstance(until[0], datetime):
+                    local_until = datetime.combine(
+                        until[0], time(23, 59, 59), ZoneInfo(self.time_tree_event.end_timezone)
+                    )
+                    recurrence_rule["UNTIL"] = [local_until.astimezone(ZoneInfo("UTC"))]
+                event.add(name, recurrence_rule, parameters)
             elif name.lower() == "exdate" or name.lower() == "rdate":
                 event.add(name, vDDDLists.from_ical(value), parameters)
             else:

--- a/timetree_exporter/formatter.py
+++ b/timetree_exporter/formatter.py
@@ -179,7 +179,9 @@ class ICalEventFormatter:
                     and not isinstance(until[0], datetime)
                 ):
                     local_until = datetime.combine(
-                        until[0], time(23, 59, 59), ZoneInfo(self.time_tree_event.end_timezone)
+                        until[0],
+                        time(23, 59, 59),
+                        ZoneInfo(self.time_tree_event.start_timezone),
                     )
                     recurrence_rule["UNTIL"] = [local_until.astimezone(ZoneInfo("UTC"))]
                 event.add(name, recurrence_rule, parameters)

--- a/timetree_exporter/formatter.py
+++ b/timetree_exporter/formatter.py
@@ -172,7 +172,12 @@ class ICalEventFormatter:
             if name.lower() == "rrule":
                 recurrence_rule = vRecur.from_ical(value)
                 until = recurrence_rule.get("UNTIL")
-                if until and isinstance(until[0], date) and not isinstance(until[0], datetime):
+                if (
+                    until
+                    and not self.time_tree_event.all_day
+                    and isinstance(until[0], date)
+                    and not isinstance(until[0], datetime)
+                ):
                     local_until = datetime.combine(
                         until[0], time(23, 59, 59), ZoneInfo(self.time_tree_event.end_timezone)
                     )


### PR DESCRIPTION
## Summary
Fixes an issue where the final occurrence of a recurring event could disappear when TimeTree provides a date-only `UNTIL` value in an RRULE.
## What Changed
- Converts date-only RRULE `UNTIL` values for timed events to the end of that local day in UTC.
- Uses the event start timezone when interpreting the recurrence end date.
- Keeps all-day event `UNTIL` values as dates.
- Adds tests for timed events, timezone handling, and all-day recurrence behavior.
## Why
Calendar RRULE `UNTIL` values for timed events are evaluated as datetimes. A date-only value could be interpreted too early, excluding the intended final occurrence. Normalizing it to `23:59:59` in the event timezone preserves the full recurrence date.