### PR TITLE
refactor: exporter CLI modules

### DIFF
--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,6 +1,7 @@
 """Tests for TimeTree calendar API helpers."""
 
 from timetree_exporter.api.calendar import TimeTreeCalendar
+from timetree_exporter.config import configure_developer_mode
 
 
 class _FakeResponse:
@@ -64,3 +65,32 @@ def test_raw_responses_are_not_recorded_by_default():
     calendar = _calendar_with_metadata_response({"calendars": []}, capture_raw_responses=False)
 
     assert calendar.raw_responses == []
+
+
+def test_calendar_uses_global_developer_mode_for_raw_capture():
+    """Calendar API should read raw capture state from global developer config."""
+    configure_developer_mode(enabled=True)
+
+    try:
+        calendar = TimeTreeCalendar("dummy-session-id")
+        assert calendar.capture_raw_responses is True
+    finally:
+        configure_developer_mode()
+
+
+def test_api_calls_write_raw_responses_when_developer_output_is_configured(tmp_path):
+    """API calls should write their own raw diagnostics when developer mode is active."""
+    configure_developer_mode(raw_output_dir=tmp_path)
+
+    try:
+        calendar = TimeTreeCalendar("dummy-session-id")
+        calendar.session = _FakeSession({"calendars": [{"name": "Family"}]})
+        calendar.get_metadata()
+        calendar.session = _FakeSession({"calendar_labels": []})
+        calendar.get_labels(1)
+    finally:
+        configure_developer_mode()
+
+    assert (tmp_path / "01_calendars.json").exists()
+    assert (tmp_path / "calendar_1/02_labels.json").exists()
+    assert not (tmp_path / "calendar_1/03_events_sync.json").exists()

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -30,34 +30,32 @@ def _calendar_with_metadata_response(payload, capture_raw_responses=True):
     return calendar
 
 
-def test_write_raw_responses_writes_captured_payloads(tmp_path):
-    """Captured TimeTree responses should be available for offline inspection."""
-    calendar = _calendar_with_metadata_response({"calendars": [{"name": "Family"}]})
-
-    written = calendar.write_raw_responses(tmp_path)
-
-    assert written == [tmp_path / "01_calendars.json"]
-    assert '"name": "Family"' in written[0].read_text(encoding="utf-8")
-
-
 def test_raw_event_response_filename_includes_calendar_id(tmp_path):
     """Raw event response filenames should identify the selected calendar."""
-    calendar = TimeTreeCalendar("dummy-session-id", capture_raw_responses=True)
-    calendar.session = _FakeSession({"events": [], "chunk": False})
+    configure_developer_mode(raw_output_dir=tmp_path)
 
-    calendar.get_events(1, "Family & Work")
+    try:
+        calendar = TimeTreeCalendar("dummy-session-id")
+        calendar.session = _FakeSession({"events": [], "chunk": False})
+        calendar.get_events(1, "Family & Work")
+    finally:
+        configure_developer_mode()
 
-    assert calendar.write_raw_responses(tmp_path) == [tmp_path / "calendar_1/01_events_sync.json"]
+    assert (tmp_path / "calendar_1/01_events_sync.json").exists()
 
 
 def test_raw_label_response_filename_includes_calendar_id(tmp_path):
     """Raw label response filenames should identify the selected calendar."""
-    calendar = TimeTreeCalendar("dummy-session-id", capture_raw_responses=True)
-    calendar.session = _FakeSession({"calendar_labels": []})
+    configure_developer_mode(raw_output_dir=tmp_path)
 
-    calendar.get_labels(1)
+    try:
+        calendar = TimeTreeCalendar("dummy-session-id")
+        calendar.session = _FakeSession({"calendar_labels": []})
+        calendar.get_labels(1)
+    finally:
+        configure_developer_mode()
 
-    assert calendar.write_raw_responses(tmp_path) == [tmp_path / "calendar_1/01_labels.json"]
+    assert (tmp_path / "calendar_1/01_labels.json").exists()
 
 
 def test_raw_responses_are_not_recorded_by_default():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
+from timetree_exporter.calendar import Calendar
 from timetree_exporter.cli import (
     DEVELOPER_MODE_ENV,
     RAW_OUTPUT_DIR,
@@ -53,7 +54,12 @@ class _Args:
 
 def test_list_labels_and_exit_handles_invalid_or_missing_color(capsys):
     """Listing labels should not fail when color is empty or malformed."""
-    list_labels_and_exit(_FakeCalendarApi(), "dummy-calendar-id")
+    calendar = Calendar(
+        _FakeCalendarApi(),
+        {"id": "dummy-calendar-id", "name": "Calendar", "alias_code": "code"},
+    )
+
+    list_labels_and_exit(calendar)
 
     output = capsys.readouterr().out
 
@@ -133,8 +139,9 @@ def test_exporter_fetches_labels_and_writes_single_calendar(tmp_path, normal_eve
     """Exporter should own fetching labels, fetching events, and writing output."""
     api = _FakeExportCalendarApi([normal_event_data], {})
     output_path = tmp_path / "calendar.ics"
+    calendar = Calendar(api, {"id": "calendar-id", "name": "Calendar Name", "alias_code": "code"})
 
-    Exporter(output_path).export(api, "calendar-id", "Calendar Name")
+    Exporter(calendar, output_path).export()
 
     serialized = output_path.read_text(encoding="utf-8")
     assert api.fetched_events_for == ("calendar-id", "Calendar Name")
@@ -149,8 +156,9 @@ def test_exporter_writes_split_calendars_by_label(tmp_path, labeled_event_data):
         {3: {"name": "Work / Home", "color": "#ff00aa"}},
     )
     output_path = tmp_path / "calendar.ics"
+    calendar = Calendar(api, {"id": "calendar-id", "name": "Calendar Name", "alias_code": "code"})
 
-    Exporter(output_path, split_by_label=True).export(api, "calendar-id", "Calendar Name")
+    Exporter(calendar, output_path, split_by_label=True).export()
 
     split_path = tmp_path / "calendar_Work___Home.ics"
     serialized = split_path.read_text(encoding="utf-8")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,7 +10,12 @@ from timetree_exporter.cli import (
     raw_output_dir,
 )
 from timetree_exporter.event import TimeTreeEvent
-from timetree_exporter.exporter import create_calendar, label_suffix_for_group, write_calendar
+from timetree_exporter.exporter import (
+    Exporter,
+    create_calendar,
+    label_suffix_for_group,
+    write_calendar,
+)
 from timetree_exporter.formatter import ICalEventFormatter
 
 
@@ -21,6 +26,22 @@ class _FakeCalendarApi:
             "2": {"name": "Empty", "color": ""},
             "3": {"name": "Malformed", "color": "#zzzzzz"},
         }
+
+
+class _FakeExportCalendarApi:
+    def __init__(self, events, labels):
+        self.events = events
+        self.labels = labels
+        self.fetched_events_for = None
+        self.fetched_labels_for = None
+
+    def get_events(self, calendar_id, calendar_name):
+        self.fetched_events_for = (calendar_id, calendar_name)
+        return self.events
+
+    def get_labels(self, calendar_id):
+        self.fetched_labels_for = calendar_id
+        return self.labels
 
 
 class _Args:
@@ -105,3 +126,32 @@ def test_write_calendar_adds_bounded_vtimezone_before_events(tmp_path, normal_ev
     assert "TZID:Asia/Taipei" in serialized
     assert "TZOFFSETTO:+0800" in serialized
     assert serialized.index("BEGIN:VTIMEZONE") < serialized.index("BEGIN:VEVENT")
+
+
+def test_exporter_fetches_labels_and_writes_single_calendar(tmp_path, normal_event_data):
+    """Exporter should own fetching labels, fetching events, and writing output."""
+    api = _FakeExportCalendarApi([normal_event_data], {})
+    output_path = tmp_path / "calendar.ics"
+
+    Exporter(api, "calendar-id", "Calendar Name", output_path).export()
+
+    serialized = output_path.read_text(encoding="utf-8")
+    assert api.fetched_events_for == ("calendar-id", "Calendar Name")
+    assert api.fetched_labels_for == "calendar-id"
+    assert "SUMMARY:測試一般活動" in serialized
+
+
+def test_exporter_writes_split_calendars_by_label(tmp_path, labeled_event_data):
+    """Exporter should write split files when configured to split by label."""
+    api = _FakeExportCalendarApi(
+        [labeled_event_data],
+        {3: {"name": "Work / Home", "color": "#ff00aa"}},
+    )
+    output_path = tmp_path / "calendar.ics"
+
+    Exporter(api, "calendar-id", "Calendar Name", output_path, split_by_label=True).export()
+
+    split_path = tmp_path / "calendar_Work___Home.ics"
+    serialized = split_path.read_text(encoding="utf-8")
+    assert not output_path.exists()
+    assert "SUMMARY:測試有標籤活動" in serialized

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,16 +3,14 @@
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from timetree_exporter.__main__ import (
+from timetree_exporter.cli import (
     DEVELOPER_MODE_ENV,
     RAW_OUTPUT_DIR,
-    create_calendar,
-    label_suffix_for_group,
     list_labels_and_exit,
     raw_output_dir,
-    write_calendar,
 )
 from timetree_exporter.event import TimeTreeEvent
+from timetree_exporter.exporter import create_calendar, label_suffix_for_group, write_calendar
 from timetree_exporter.formatter import ICalEventFormatter
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,6 +9,7 @@ from timetree_exporter.cli import (
     list_labels_and_exit,
     raw_output_dir,
 )
+from timetree_exporter.config import configure_developer_mode, get_raw_output_dir
 from timetree_exporter.event import TimeTreeEvent
 from timetree_exporter.exporter import (
     Exporter,
@@ -133,7 +134,7 @@ def test_exporter_fetches_labels_and_writes_single_calendar(tmp_path, normal_eve
     api = _FakeExportCalendarApi([normal_event_data], {})
     output_path = tmp_path / "calendar.ics"
 
-    Exporter(api, "calendar-id", "Calendar Name", output_path).export()
+    Exporter(output_path).export(api, "calendar-id", "Calendar Name")
 
     serialized = output_path.read_text(encoding="utf-8")
     assert api.fetched_events_for == ("calendar-id", "Calendar Name")
@@ -149,9 +150,19 @@ def test_exporter_writes_split_calendars_by_label(tmp_path, labeled_event_data):
     )
     output_path = tmp_path / "calendar.ics"
 
-    Exporter(api, "calendar-id", "Calendar Name", output_path, split_by_label=True).export()
+    Exporter(output_path, split_by_label=True).export(api, "calendar-id", "Calendar Name")
 
     split_path = tmp_path / "calendar_Work___Home.ics"
     serialized = split_path.read_text(encoding="utf-8")
     assert not output_path.exists()
     assert "SUMMARY:測試有標籤活動" in serialized
+
+
+def test_developer_mode_globally_enables_raw_output():
+    """Developer mode should be readable globally by modules."""
+    configure_developer_mode(enabled=True)
+
+    try:
+        assert get_raw_output_dir() == RAW_OUTPUT_DIR
+    finally:
+        configure_developer_mode()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,8 +5,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
-from timetree_exporter.__main__ import create_calendar
 from timetree_exporter.event import TimeTreeEvent
+from timetree_exporter.exporter import create_calendar
 from timetree_exporter.formatter import ICalEventFormatter
 from timetree_exporter.utils import (
     add_bounded_timezones_before_events,

--- a/timetree_exporter/__main__.py
+++ b/timetree_exporter/__main__.py
@@ -6,6 +6,7 @@ import logging
 
 from timetree_exporter.api.auth import login
 from timetree_exporter.api.calendar import TimeTreeCalendar
+from timetree_exporter.calendar import Calendar
 from timetree_exporter.cli import (
     configure_logging,
     list_labels_and_exit,
@@ -19,12 +20,8 @@ from timetree_exporter.exporter import Exporter
 logger = logging.getLogger(__name__)
 
 
-def select_calendar(
-    email: str,
-    password: str,
-    calendar_code: str,
-):
-    """Authenticate and select a calendar. Returns (calendar_api, calendar_id, calendar_name)."""
+def select_calendar(email: str, password: str, calendar_code: str):
+    """Authenticate and select a calendar."""
     use_code = bool(calendar_code)
     session_id = login(email, password)
     calendar = TimeTreeCalendar(session_id)
@@ -68,7 +65,7 @@ def select_calendar(
         idx = int(calendar_num) - 1
         metadata = metadatas[idx]
 
-    return calendar, metadata["id"], metadata["name"]
+    return Calendar(calendar, metadata)
 
 
 def main():
@@ -76,21 +73,17 @@ def main():
     args = parse_args()
     configure_logging(args.verbose)
     configure_developer_mode(args.developer_mode, args.raw_output_dir)
-    exporter = Exporter(args.output, split_by_label=args.split_by_label)
 
     email = resolve_email(args.email)
     password = resolve_password()
-    calendar_api, calendar_id, calendar_name = select_calendar(
-        email,
-        password,
-        args.calendar_code,
-    )
+    calendar = select_calendar(email, password, args.calendar_code)
+    exporter = Exporter(calendar, args.output, split_by_label=args.split_by_label)
 
     if args.list_labels:
-        list_labels_and_exit(calendar_api, calendar_id)
+        list_labels_and_exit(calendar)
         return
 
-    exporter.export(calendar_api, calendar_id, calendar_name)
+    exporter.export()
 
 
 if __name__ == "__main__":

--- a/timetree_exporter/__main__.py
+++ b/timetree_exporter/__main__.py
@@ -2,25 +2,26 @@
 This module login in to TimeTree and converts Timetree events to iCal format.
 """
 
-import argparse
 import logging
-import os
-import re
-from collections import defaultdict
-from importlib.metadata import version
-from pathlib import Path
 
-from icalendar import Calendar
-
-from timetree_exporter import ICalEventFormatter, TimeTreeEvent, __version__
 from timetree_exporter.api.auth import login
 from timetree_exporter.api.calendar import TimeTreeCalendar
-from timetree_exporter.utils import add_bounded_timezones_before_events, safe_getpass
+from timetree_exporter.cli import (
+    configure_logging,
+    list_labels_and_exit,
+    parse_args,
+    raw_output_dir,
+    resolve_email,
+    resolve_password,
+)
+from timetree_exporter.exporter import (
+    build_single_calendar,
+    group_events_by_label,
+    write_calendar,
+    write_split_calendars,
+)
 
 logger = logging.getLogger(__name__)
-package_logger = logging.getLogger(__package__)
-DEVELOPER_MODE_ENV = "TIMETREE_EXPORTER_DEVELOPER"
-RAW_OUTPUT_DIR = "raw-timetree"
 
 
 def select_calendar(
@@ -76,238 +77,11 @@ def select_calendar(
     return calendar, metadata["id"], metadata["name"]
 
 
-def get_events(email: str, password: str, calendar_code: str):
-    """Get events from the Timetree API."""
-    calendar, calendar_id, calendar_name = select_calendar(email, password, calendar_code)
-    return calendar.get_events(calendar_id, calendar_name)
-
-
-def create_calendar():
-    """Create a new iCalendar object with standard properties."""
-    cal = Calendar()
-    cal.add("prodid", f"-//TimeTree Exporter {version('timetree_exporter')}//EN")
-    cal.add("version", "2.0")
-    return cal
-
-
-def write_calendar(cal, output_path: str):
-    """Write a calendar to an .ics file."""
-    add_bounded_timezones_before_events(cal)
-
-    # Transform the output path to a Path object for better handling
-    path = Path(output_path)
-    with path.open("wb") as f:
-        f.write(cal.to_ical())
-        logger.info("The .ics calendar file is saved to %s", path.resolve())
-
-
-def sanitize_filename(name):
-    """Sanitize a string for use as a filename component."""
-    # Replace any non-alphanumeric characters (except hyphen/underscore) with underscore
-    return re.sub(r"[^\w\-]", "_", name).strip("_")
-
-
-def raw_output_dir(args):
-    """Return the raw response output directory when developer mode is enabled."""
-    if args.raw_output_dir:
-        return args.raw_output_dir
-    if args.developer_mode or os.environ.get(DEVELOPER_MODE_ENV) == "1":
-        return RAW_OUTPUT_DIR
-    return None
-
-
-def parse_args():
-    """Parse CLI arguments."""
-    parser = argparse.ArgumentParser(
-        description="Convert Timetree events to iCal format",
-        prog="timetree_exporter",
-    )
-    parser.add_argument(
-        "-o",
-        "--output",
-        type=str,
-        help="Path to the output iCal file",
-        default=str(Path.cwd() / "timetree.ics"),
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        help="Increase output verbosity",
-        action="store_true",
-    )
-    parser.add_argument(
-        "-e",
-        "--email",
-        type=str,
-        help="Email address",
-        default=None,
-    )
-    parser.add_argument(
-        "-c",
-        "--calendar_code",
-        type=str,
-        help="The Calendar Code you want to export",
-        default=None,
-    )
-    parser.add_argument(
-        "--version",
-        action="version",
-        version=f"%(prog)s {__version__}",
-    )
-    parser.add_argument(
-        "--list-labels",
-        help="List labels for the selected calendar and exit",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--split-by-label",
-        help="Export events into separate .ics files grouped by label",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--developer-mode",
-        help=(
-            "Enable developer diagnostics, including raw TimeTree API response output "
-            f"(or set {DEVELOPER_MODE_ENV}=1)"
-        ),
-        action="store_true",
-    )
-    parser.add_argument(
-        "--raw-output-dir",
-        type=str,
-        help="Directory for developer-mode raw TimeTree API JSON responses",
-        default=None,
-    )
-    return parser.parse_args()
-
-
-def resolve_email(cli_email):
-    """Resolve email from CLI arg, env var, or prompt."""
-    if cli_email:
-        return cli_email
-    env_email = os.environ.get("TIMETREE_EMAIL")
-    if env_email:
-        return env_email
-    return input("Enter your email address: ")
-
-
-def resolve_password():
-    """Resolve password from env var or prompt."""
-    env_password = os.environ.get("TIMETREE_PASSWORD")
-    if env_password:
-        return env_password
-    return safe_getpass(prompt="Enter your password: ", echo_char="*")
-
-
-def configure_logging(verbose):
-    """Configure package logging level based on CLI flags."""
-    if verbose:
-        package_logger.setLevel(logging.DEBUG)
-
-
-def list_labels_and_exit(calendar_api, calendar_id):
-    """Print labels for a calendar and return."""
-    labels = calendar_api.get_labels(calendar_id)
-    if not labels:
-        print("No labels found (the API response format may differ — use -v to debug)")
-        return
-
-    for i, (_label_id, label_info) in enumerate(labels.items(), 1):
-        color_hex = (label_info.get("color") or "").strip()
-        normalized = color_hex.lstrip("#")
-
-        if len(normalized) == 6 and re.fullmatch(r"[0-9A-Fa-f]{6}", normalized):
-            r = int(normalized[0:2], 16)
-            g = int(normalized[2:4], 16)
-            b = int(normalized[4:6], 16)
-            dot = f"\033[38;2;{r};{g};{b}m●\033[0m"
-        else:
-            dot = "●"
-
-        print(f"{i:>2}. {dot} {label_info['name']}")
-
-
 def fetch_labels(calendar_api, calendar_id):
     """Fetch labels and log count."""
     labels = calendar_api.get_labels(calendar_id)
     logger.info("Found %d labels", len(labels))
     return labels
-
-
-def build_single_calendar(events, labels):
-    """Build single output calendar from events."""
-    cal = create_calendar()
-    label_lookup = {lid: info["name"] for lid, info in labels.items()} if labels else {}
-    color_lookup = {lid: info["color"] for lid, info in labels.items()} if labels else {}
-
-    for event in events:
-        time_tree_event = TimeTreeEvent.from_dict(event)
-        label_name = label_lookup.get(time_tree_event.label_id)
-        color = color_lookup.get(time_tree_event.label_id)
-        formatter = ICalEventFormatter(time_tree_event, label_name=label_name, color=color)
-        ical_event = formatter.to_ical()
-        if ical_event is not None:
-            cal.add_component(ical_event)
-
-    return cal
-
-
-def group_events_by_label(events, labels):
-    """Group converted iCal events by label id (or None for unlabeled)."""
-    grouped = defaultdict(list)
-
-    for event in events:
-        time_tree_event = TimeTreeEvent.from_dict(event)
-        label_info = labels.get(time_tree_event.label_id)
-        label_name = label_info["name"] if label_info is not None else None
-        color = label_info["color"] if label_info is not None else None
-        formatter = ICalEventFormatter(time_tree_event, label_name=label_name, color=color)
-        ical_event = formatter.to_ical()
-
-        if ical_event is None:
-            continue
-
-        group_key = time_tree_event.label_id if label_info is not None else None
-        grouped[group_key].append(ical_event)
-
-    return grouped
-
-
-def label_suffix_for_group(group_key, labels):
-    """Return output filename suffix for a label group."""
-    if group_key is None:
-        return "unlabeled"
-    name = sanitize_filename(labels[group_key]["name"])
-    if name:
-        return name
-    return sanitize_filename(f"label_{group_key}")
-
-
-def write_split_calendars(grouped_events, labels, output, event_count):
-    """Write grouped events into separate calendar files."""
-    output_path = Path(output)
-
-    for group_key, ical_events in grouped_events.items():
-        label_suffix = label_suffix_for_group(group_key, labels)
-        cal = create_calendar()
-        for ical_event in ical_events:
-            cal.add_component(ical_event)
-        if output_path.suffix:
-            split_path = output_path.with_name(
-                f"{output_path.stem}_{label_suffix}{output_path.suffix}"
-            )
-        else:
-            split_path = output_path.with_name(f"{output_path.name}_{label_suffix}.ics")
-        logger.info("%d events for label '%s'", len(ical_events), label_suffix)
-        write_calendar(cal, split_path)
-
-    total = sum(len(evts) for evts in grouped_events.values())
-    logger.info(
-        "A total of %d/%d events split into %d files",
-        total,
-        event_count,
-        len(grouped_events),
-    )
 
 
 def main():

--- a/timetree_exporter/__main__.py
+++ b/timetree_exporter/__main__.py
@@ -14,12 +14,7 @@ from timetree_exporter.cli import (
     resolve_email,
     resolve_password,
 )
-from timetree_exporter.exporter import (
-    build_single_calendar,
-    group_events_by_label,
-    write_calendar,
-    write_split_calendars,
-)
+from timetree_exporter.exporter import Exporter
 
 logger = logging.getLogger(__name__)
 
@@ -77,13 +72,6 @@ def select_calendar(
     return calendar, metadata["id"], metadata["name"]
 
 
-def fetch_labels(calendar_api, calendar_id):
-    """Fetch labels and log count."""
-    labels = calendar_api.get_labels(calendar_id)
-    logger.info("Found %d labels", len(labels))
-    return labels
-
-
 def main():
     """Main function for the Timetree Exporter."""
     args = parse_args()
@@ -106,27 +94,18 @@ def main():
             logger.info("Wrote %d raw TimeTree response(s) to %s", len(written), raw_dir)
         return
 
-    events = calendar_api.get_events(calendar_id, calendar_name)
-    logger.info("Found %d events", len(events))
-    labels = fetch_labels(calendar_api, calendar_id)
+    exporter = Exporter(
+        calendar_api,
+        calendar_id,
+        calendar_name,
+        args.output,
+        split_by_label=args.split_by_label,
+    )
+    exporter.export()
 
     if raw_dir:
         written = calendar_api.write_raw_responses(raw_dir)
         logger.info("Wrote %d raw TimeTree response(s) to %s", len(written), raw_dir)
-
-    if args.split_by_label:
-        grouped_events = group_events_by_label(events, labels)
-        write_split_calendars(grouped_events, labels, args.output, len(events))
-        return
-
-    cal = build_single_calendar(events, labels)
-    logger.info(
-        "A total of %d/%d events are added to the calendar",
-        len(cal.subcomponents),
-        len(events),
-    )
-
-    write_calendar(cal, args.output)
 
 
 if __name__ == "__main__":

--- a/timetree_exporter/__main__.py
+++ b/timetree_exporter/__main__.py
@@ -10,10 +10,10 @@ from timetree_exporter.cli import (
     configure_logging,
     list_labels_and_exit,
     parse_args,
-    raw_output_dir,
     resolve_email,
     resolve_password,
 )
+from timetree_exporter.config import configure_developer_mode
 from timetree_exporter.exporter import Exporter
 
 logger = logging.getLogger(__name__)
@@ -23,12 +23,11 @@ def select_calendar(
     email: str,
     password: str,
     calendar_code: str,
-    capture_raw_responses: bool = False,
 ):
     """Authenticate and select a calendar. Returns (calendar_api, calendar_id, calendar_name)."""
     use_code = bool(calendar_code)
     session_id = login(email, password)
-    calendar = TimeTreeCalendar(session_id, capture_raw_responses=capture_raw_responses)
+    calendar = TimeTreeCalendar(session_id)
     metadatas = calendar.get_metadata()
 
     # Filter out deactivated calendars
@@ -76,7 +75,8 @@ def main():
     """Main function for the Timetree Exporter."""
     args = parse_args()
     configure_logging(args.verbose)
-    raw_dir = raw_output_dir(args)
+    configure_developer_mode(args.developer_mode, args.raw_output_dir)
+    exporter = Exporter(args.output, split_by_label=args.split_by_label)
 
     email = resolve_email(args.email)
     password = resolve_password()
@@ -84,28 +84,13 @@ def main():
         email,
         password,
         args.calendar_code,
-        capture_raw_responses=raw_dir is not None,
     )
 
     if args.list_labels:
         list_labels_and_exit(calendar_api, calendar_id)
-        if raw_dir:
-            written = calendar_api.write_raw_responses(raw_dir)
-            logger.info("Wrote %d raw TimeTree response(s) to %s", len(written), raw_dir)
         return
 
-    exporter = Exporter(
-        calendar_api,
-        calendar_id,
-        calendar_name,
-        args.output,
-        split_by_label=args.split_by_label,
-    )
-    exporter.export()
-
-    if raw_dir:
-        written = calendar_api.write_raw_responses(raw_dir)
-        logger.info("Wrote %d raw TimeTree response(s) to %s", len(written), raw_dir)
+    exporter.export(calendar_api, calendar_id, calendar_name)
 
 
 if __name__ == "__main__":

--- a/timetree_exporter/api/calendar.py
+++ b/timetree_exporter/api/calendar.py
@@ -45,15 +45,6 @@ class TimeTreeCalendar:
         """Sanitize a string for use as a path component."""
         return re.sub(r"[^\w\-]", "_", name).strip("_")
 
-    def write_raw_responses(self, output_dir):
-        """Write captured TimeTree API JSON payloads to a directory."""
-        written = []
-
-        for index, (name, payload) in enumerate(self.raw_responses, 1):
-            written.append(self._write_raw_response(output_dir, index, name, payload))
-
-        return written
-
     def _write_raw_response(self, output_dir, index, name, payload):
         """Write one raw TimeTree API JSON payload to a directory."""
         path = Path(output_dir)

--- a/timetree_exporter/api/calendar.py
+++ b/timetree_exporter/api/calendar.py
@@ -11,6 +11,7 @@ import requests
 from requests.exceptions import HTTPError
 
 from timetree_exporter.api.const import API_BASEURI, API_USER_AGENT
+from timetree_exporter.config import get_raw_output_dir
 
 logger = logging.getLogger(__name__)
 
@@ -20,10 +21,14 @@ class TimeTreeCalendar:
     Timetree calendar API
     """
 
-    def __init__(self, session_id: str, capture_raw_responses: bool = False):
+    def __init__(self, session_id: str, capture_raw_responses: bool | None = None):
         self.session = requests.Session()
         self.session.cookies.set("_session_id", session_id)
-        self.capture_raw_responses = capture_raw_responses
+        self.capture_raw_responses = (
+            get_raw_output_dir() is not None
+            if capture_raw_responses is None
+            else capture_raw_responses
+        )
         self.raw_responses = []
 
     def _record_raw_response(self, name, payload):
@@ -31,6 +36,9 @@ class TimeTreeCalendar:
         if not self.capture_raw_responses:
             return
         self.raw_responses.append((name, payload))
+        raw_output_dir = get_raw_output_dir()
+        if raw_output_dir:
+            self._write_raw_response(raw_output_dir, len(self.raw_responses), name, payload)
 
     @staticmethod
     def _sanitize_path_part(name):
@@ -39,22 +47,27 @@ class TimeTreeCalendar:
 
     def write_raw_responses(self, output_dir):
         """Write captured TimeTree API JSON payloads to a directory."""
-        path = Path(output_dir)
-        path.mkdir(parents=True, exist_ok=True)
         written = []
 
         for index, (name, payload) in enumerate(self.raw_responses, 1):
-            *dirs, filename = [self._sanitize_path_part(part) for part in name.split("/")]
-            filename = f"{index:02d}_{filename or 'response'}.json"
-            file_path = path.joinpath(*dirs, filename)
-            file_path.parent.mkdir(parents=True, exist_ok=True)
-            file_path.write_text(
-                json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True),
-                encoding="utf-8",
-            )
-            written.append(file_path)
+            written.append(self._write_raw_response(output_dir, index, name, payload))
 
         return written
+
+    def _write_raw_response(self, output_dir, index, name, payload):
+        """Write one raw TimeTree API JSON payload to a directory."""
+        path = Path(output_dir)
+        path.mkdir(parents=True, exist_ok=True)
+        *dirs, filename = [self._sanitize_path_part(part) for part in name.split("/")]
+        filename = f"{index:02d}_{filename or 'response'}.json"
+        file_path = path.joinpath(*dirs, filename)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True),
+            encoding="utf-8",
+        )
+        logger.info("Wrote raw TimeTree response to %s", file_path)
+        return file_path
 
     def get_metadata(self):
         """

--- a/timetree_exporter/calendar.py
+++ b/timetree_exporter/calendar.py
@@ -1,0 +1,45 @@
+"""TimeTree calendar domain object."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class CalendarApi(Protocol):
+    """API methods needed by a selected calendar."""
+
+    def get_events(self, calendar_id, calendar_name):
+        """Return events for a calendar."""
+
+    def get_labels(self, calendar_id):
+        """Return labels for a calendar."""
+
+
+@dataclass(frozen=True)
+class Calendar:
+    """TimeTree calendar Object."""
+
+    api: CalendarApi
+    metadata: dict
+
+    @property
+    def id(self):
+        """Return the calendar id."""
+        return self.metadata["id"]
+
+    @property
+    def name(self):
+        """Return the calendar name."""
+        return self.metadata["name"]
+
+    @property
+    def alias_code(self):
+        """Return the calendar alias code."""
+        return self.metadata["alias_code"]
+
+    def get_events(self):
+        """Return events for this calendar."""
+        return self.api.get_events(self.id, self.name)
+
+    def get_labels(self):
+        """Return labels for this calendar."""
+        return self.api.get_labels(self.id)

--- a/timetree_exporter/cli.py
+++ b/timetree_exporter/cli.py
@@ -128,9 +128,9 @@ def sanitize_filename(name):
     return re.sub(r"[^\w\-]", "_", name).strip("_")
 
 
-def list_labels_and_exit(calendar_api, calendar_id):
+def list_labels_and_exit(calendar):
     """Print labels for a calendar and return."""
-    labels = calendar_api.get_labels(calendar_id)
+    labels = calendar.get_labels()
     if not labels:
         print("No labels found (the API response format may differ — use -v to debug)")
         return

--- a/timetree_exporter/cli.py
+++ b/timetree_exporter/cli.py
@@ -25,7 +25,6 @@ __all__ = [
     "raw_output_dir",
     "resolve_email",
     "resolve_password",
-    "sanitize_filename",
 ]
 
 
@@ -121,11 +120,6 @@ def configure_logging(verbose):
 def raw_output_dir(args):
     """Return the raw response output directory for parsed CLI args."""
     return resolve_raw_output_dir(args.developer_mode, args.raw_output_dir)
-
-
-def sanitize_filename(name):
-    """Sanitize a string for use as a filename component."""
-    return re.sub(r"[^\w\-]", "_", name).strip("_")
 
 
 def list_labels_and_exit(calendar):

--- a/timetree_exporter/cli.py
+++ b/timetree_exporter/cli.py
@@ -1,0 +1,139 @@
+"""CLI helpers for timetree_exporter."""
+
+import argparse
+import logging
+import os
+import re
+from pathlib import Path
+
+from timetree_exporter import __version__
+from timetree_exporter.utils import safe_getpass
+
+package_logger = logging.getLogger(__package__)
+DEVELOPER_MODE_ENV = "TIMETREE_EXPORTER_DEVELOPER"
+RAW_OUTPUT_DIR = "raw-timetree"
+
+
+def parse_args():
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Convert Timetree events to iCal format",
+        prog="timetree_exporter",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        help="Path to the output iCal file",
+        default=str(Path.cwd() / "timetree.ics"),
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="Increase output verbosity",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-e",
+        "--email",
+        type=str,
+        help="Email address",
+        default=None,
+    )
+    parser.add_argument(
+        "-c",
+        "--calendar_code",
+        type=str,
+        help="The Calendar Code you want to export",
+        default=None,
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    parser.add_argument(
+        "--list-labels",
+        help="List labels for the selected calendar and exit",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--split-by-label",
+        help="Export events into separate .ics files grouped by label",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--developer-mode",
+        help=(
+            "Enable developer diagnostics, including raw TimeTree API response output "
+            f"(or set {DEVELOPER_MODE_ENV}=1)"
+        ),
+        action="store_true",
+    )
+    parser.add_argument(
+        "--raw-output-dir",
+        type=str,
+        help="Directory for developer-mode raw TimeTree API JSON responses",
+        default=None,
+    )
+    return parser.parse_args()
+
+
+def resolve_email(cli_email):
+    """Resolve email from CLI arg, env var, or prompt."""
+    if cli_email:
+        return cli_email
+    env_email = os.environ.get("TIMETREE_EMAIL")
+    if env_email:
+        return env_email
+    return input("Enter your email address: ")
+
+
+def resolve_password():
+    """Resolve password from env var or prompt."""
+    env_password = os.environ.get("TIMETREE_PASSWORD")
+    if env_password:
+        return env_password
+    return safe_getpass(prompt="Enter your password: ", echo_char="*")
+
+
+def configure_logging(verbose):
+    """Configure package logging level based on CLI flags."""
+    if verbose:
+        package_logger.setLevel(logging.DEBUG)
+
+
+def raw_output_dir(args):
+    """Return the raw response output directory when developer mode is enabled."""
+    if args.raw_output_dir:
+        return args.raw_output_dir
+    if args.developer_mode or os.environ.get(DEVELOPER_MODE_ENV) == "1":
+        return RAW_OUTPUT_DIR
+    return None
+
+
+def sanitize_filename(name):
+    """Sanitize a string for use as a filename component."""
+    return re.sub(r"[^\w\-]", "_", name).strip("_")
+
+
+def list_labels_and_exit(calendar_api, calendar_id):
+    """Print labels for a calendar and return."""
+    labels = calendar_api.get_labels(calendar_id)
+    if not labels:
+        print("No labels found (the API response format may differ — use -v to debug)")
+        return
+
+    for i, (_label_id, label_info) in enumerate(labels.items(), 1):
+        color_hex = (label_info.get("color") or "").strip()
+        normalized = color_hex.lstrip("#")
+
+        if len(normalized) == 6 and re.fullmatch(r"[0-9A-Fa-f]{6}", normalized):
+            r = int(normalized[0:2], 16)
+            g = int(normalized[2:4], 16)
+            b = int(normalized[4:6], 16)
+            dot = f"\033[38;2;{r};{g};{b}m●\033[0m"
+        else:
+            dot = "●"
+
+        print(f"{i:>2}. {dot} {label_info['name']}")

--- a/timetree_exporter/cli.py
+++ b/timetree_exporter/cli.py
@@ -7,11 +7,26 @@ import re
 from pathlib import Path
 
 from timetree_exporter import __version__
+from timetree_exporter.config import (
+    DEVELOPER_MODE_ENV,
+    RAW_OUTPUT_DIR,
+    resolve_raw_output_dir,
+)
 from timetree_exporter.utils import safe_getpass
 
 package_logger = logging.getLogger(__package__)
-DEVELOPER_MODE_ENV = "TIMETREE_EXPORTER_DEVELOPER"
-RAW_OUTPUT_DIR = "raw-timetree"
+
+__all__ = [
+    "DEVELOPER_MODE_ENV",
+    "RAW_OUTPUT_DIR",
+    "configure_logging",
+    "list_labels_and_exit",
+    "parse_args",
+    "raw_output_dir",
+    "resolve_email",
+    "resolve_password",
+    "sanitize_filename",
+]
 
 
 def parse_args():
@@ -104,12 +119,8 @@ def configure_logging(verbose):
 
 
 def raw_output_dir(args):
-    """Return the raw response output directory when developer mode is enabled."""
-    if args.raw_output_dir:
-        return args.raw_output_dir
-    if args.developer_mode or os.environ.get(DEVELOPER_MODE_ENV) == "1":
-        return RAW_OUTPUT_DIR
-    return None
+    """Return the raw response output directory for parsed CLI args."""
+    return resolve_raw_output_dir(args.developer_mode, args.raw_output_dir)
 
 
 def sanitize_filename(name):

--- a/timetree_exporter/config.py
+++ b/timetree_exporter/config.py
@@ -1,0 +1,35 @@
+"""Runtime configuration shared across timetree_exporter modules."""
+
+import os
+
+DEVELOPER_MODE_ENV = "TIMETREE_EXPORTER_DEVELOPER"
+RAW_OUTPUT_DIR = "raw-timetree"
+
+_developer_mode = False
+_raw_output_dir = None
+
+
+def configure_developer_mode(enabled=False, raw_output_dir=None):
+    """Configure developer diagnostics for the current process."""
+    global _developer_mode, _raw_output_dir
+    _developer_mode = enabled
+    _raw_output_dir = raw_output_dir
+
+
+def is_developer_mode():
+    """Return whether developer diagnostics are enabled."""
+    return _developer_mode or os.environ.get(DEVELOPER_MODE_ENV) == "1"
+
+
+def resolve_raw_output_dir(developer_mode=False, raw_output_dir=None):
+    """Return a raw response output directory for explicit settings."""
+    if raw_output_dir:
+        return raw_output_dir
+    if developer_mode or os.environ.get(DEVELOPER_MODE_ENV) == "1":
+        return RAW_OUTPUT_DIR
+    return None
+
+
+def get_raw_output_dir():
+    """Return the configured raw API response output directory, if enabled."""
+    return resolve_raw_output_dir(_developer_mode, _raw_output_dir)

--- a/timetree_exporter/exporter.py
+++ b/timetree_exporter/exporter.py
@@ -1,6 +1,7 @@
 """Build and write iCalendar exports from TimeTree events."""
 
 import logging
+import re
 from collections import defaultdict
 from importlib.metadata import version
 from pathlib import Path
@@ -8,7 +9,6 @@ from pathlib import Path
 from icalendar import Calendar as ICalendar
 
 from timetree_exporter import ICalEventFormatter, TimeTreeEvent
-from timetree_exporter.cli import sanitize_filename
 from timetree_exporter.utils import add_bounded_timezones_before_events
 
 logger = logging.getLogger(__name__)
@@ -50,6 +50,11 @@ def create_calendar():
     cal.add("prodid", f"-//TimeTree Exporter {version('timetree_exporter')}//EN")
     cal.add("version", "2.0")
     return cal
+
+
+def sanitize_filename(name):
+    """Sanitize a string for use as an export filename component."""
+    return re.sub(r"[^\w\-]", "_", name).strip("_")
 
 
 def write_calendar(cal, output_path: str):

--- a/timetree_exporter/exporter.py
+++ b/timetree_exporter/exporter.py
@@ -1,0 +1,108 @@
+"""Build and write iCalendar exports from TimeTree events."""
+
+import logging
+from collections import defaultdict
+from importlib.metadata import version
+from pathlib import Path
+
+from icalendar import Calendar
+
+from timetree_exporter import ICalEventFormatter, TimeTreeEvent
+from timetree_exporter.cli import sanitize_filename
+from timetree_exporter.utils import add_bounded_timezones_before_events
+
+logger = logging.getLogger(__name__)
+
+
+def create_calendar():
+    """Create a new iCalendar object with standard properties."""
+    cal = Calendar()
+    cal.add("prodid", f"-//TimeTree Exporter {version('timetree_exporter')}//EN")
+    cal.add("version", "2.0")
+    return cal
+
+
+def write_calendar(cal, output_path: str):
+    """Write a calendar to an .ics file."""
+    add_bounded_timezones_before_events(cal)
+
+    path = Path(output_path)
+    with path.open("wb") as f:
+        f.write(cal.to_ical())
+        logger.info("The .ics calendar file is saved to %s", path.resolve())
+
+
+def build_single_calendar(events, labels):
+    """Build single output calendar from events."""
+    cal = create_calendar()
+    label_lookup = {lid: info["name"] for lid, info in labels.items()} if labels else {}
+    color_lookup = {lid: info["color"] for lid, info in labels.items()} if labels else {}
+
+    for event in events:
+        time_tree_event = TimeTreeEvent.from_dict(event)
+        label_name = label_lookup.get(time_tree_event.label_id)
+        color = color_lookup.get(time_tree_event.label_id)
+        formatter = ICalEventFormatter(time_tree_event, label_name=label_name, color=color)
+        ical_event = formatter.to_ical()
+        if ical_event is not None:
+            cal.add_component(ical_event)
+
+    return cal
+
+
+def group_events_by_label(events, labels):
+    """Group converted iCal events by label id (or None for unlabeled)."""
+    grouped = defaultdict(list)
+
+    for event in events:
+        time_tree_event = TimeTreeEvent.from_dict(event)
+        label_info = labels.get(time_tree_event.label_id)
+        label_name = label_info["name"] if label_info is not None else None
+        color = label_info["color"] if label_info is not None else None
+        formatter = ICalEventFormatter(time_tree_event, label_name=label_name, color=color)
+        ical_event = formatter.to_ical()
+
+        if ical_event is None:
+            continue
+
+        group_key = time_tree_event.label_id if label_info is not None else None
+        grouped[group_key].append(ical_event)
+
+    return grouped
+
+
+def label_suffix_for_group(group_key, labels):
+    """Return output filename suffix for a label group."""
+    if group_key is None:
+        return "unlabeled"
+    name = sanitize_filename(labels[group_key]["name"])
+    if name:
+        return name
+    return sanitize_filename(f"label_{group_key}")
+
+
+def write_split_calendars(grouped_events, labels, output, event_count):
+    """Write grouped events into separate calendar files."""
+    output_path = Path(output)
+
+    for group_key, ical_events in grouped_events.items():
+        label_suffix = label_suffix_for_group(group_key, labels)
+        cal = create_calendar()
+        for ical_event in ical_events:
+            cal.add_component(ical_event)
+        if output_path.suffix:
+            split_path = output_path.with_name(
+                f"{output_path.stem}_{label_suffix}{output_path.suffix}"
+            )
+        else:
+            split_path = output_path.with_name(f"{output_path.name}_{label_suffix}.ics")
+        logger.info("%d events for label '%s'", len(ical_events), label_suffix)
+        write_calendar(cal, split_path)
+
+    total = sum(len(evts) for evts in grouped_events.values())
+    logger.info(
+        "A total of %d/%d events split into %d files",
+        total,
+        event_count,
+        len(grouped_events),
+    )

--- a/timetree_exporter/exporter.py
+++ b/timetree_exporter/exporter.py
@@ -57,7 +57,7 @@ def sanitize_filename(name):
     return re.sub(r"[^\w\-]", "_", name).strip("_")
 
 
-def write_calendar(cal, output_path: str):
+def write_calendar(cal, output_path: str | Path):
     """Write a calendar to an .ics file."""
     add_bounded_timezones_before_events(cal)
 

--- a/timetree_exporter/exporter.py
+++ b/timetree_exporter/exporter.py
@@ -17,19 +17,16 @@ logger = logging.getLogger(__name__)
 class Exporter:
     """Export a selected TimeTree calendar to one or more iCalendar files."""
 
-    def __init__(self, calendar_api, calendar_id, calendar_name, output, split_by_label=False):
-        self.calendar_api = calendar_api
-        self.calendar_id = calendar_id
-        self.calendar_name = calendar_name
+    def __init__(self, output, split_by_label=False):
         self.output = output
         self.split_by_label = split_by_label
 
-    def export(self):
+    def export(self, calendar_api, calendar_id, calendar_name):
         """Fetch labels and events, then write the configured iCalendar output."""
-        events = self.calendar_api.get_events(self.calendar_id, self.calendar_name)
+        events = calendar_api.get_events(calendar_id, calendar_name)
         logger.info("Found %d events", len(events))
 
-        labels = self.calendar_api.get_labels(self.calendar_id)
+        labels = calendar_api.get_labels(calendar_id)
         logger.info("Found %d labels", len(labels))
 
         if self.split_by_label:

--- a/timetree_exporter/exporter.py
+++ b/timetree_exporter/exporter.py
@@ -14,6 +14,38 @@ from timetree_exporter.utils import add_bounded_timezones_before_events
 logger = logging.getLogger(__name__)
 
 
+class Exporter:
+    """Export a selected TimeTree calendar to one or more iCalendar files."""
+
+    def __init__(self, calendar_api, calendar_id, calendar_name, output, split_by_label=False):
+        self.calendar_api = calendar_api
+        self.calendar_id = calendar_id
+        self.calendar_name = calendar_name
+        self.output = output
+        self.split_by_label = split_by_label
+
+    def export(self):
+        """Fetch labels and events, then write the configured iCalendar output."""
+        events = self.calendar_api.get_events(self.calendar_id, self.calendar_name)
+        logger.info("Found %d events", len(events))
+
+        labels = self.calendar_api.get_labels(self.calendar_id)
+        logger.info("Found %d labels", len(labels))
+
+        if self.split_by_label:
+            grouped_events = group_events_by_label(events, labels)
+            write_split_calendars(grouped_events, labels, self.output, len(events))
+            return
+
+        cal = build_single_calendar(events, labels)
+        logger.info(
+            "A total of %d/%d events are added to the calendar",
+            len(cal.subcomponents),
+            len(events),
+        )
+        write_calendar(cal, self.output)
+
+
 def create_calendar():
     """Create a new iCalendar object with standard properties."""
     cal = Calendar()

--- a/timetree_exporter/exporter.py
+++ b/timetree_exporter/exporter.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from importlib.metadata import version
 from pathlib import Path
 
-from icalendar import Calendar
+from icalendar import Calendar as ICalendar
 
 from timetree_exporter import ICalEventFormatter, TimeTreeEvent
 from timetree_exporter.cli import sanitize_filename
@@ -17,16 +17,17 @@ logger = logging.getLogger(__name__)
 class Exporter:
     """Export a selected TimeTree calendar to one or more iCalendar files."""
 
-    def __init__(self, output, split_by_label=False):
+    def __init__(self, calendar, output, split_by_label=False):
+        self.calendar = calendar
         self.output = output
         self.split_by_label = split_by_label
 
-    def export(self, calendar_api, calendar_id, calendar_name):
+    def export(self):
         """Fetch labels and events, then write the configured iCalendar output."""
-        events = calendar_api.get_events(calendar_id, calendar_name)
+        events = self.calendar.get_events()
         logger.info("Found %d events", len(events))
 
-        labels = calendar_api.get_labels(calendar_id)
+        labels = self.calendar.get_labels()
         logger.info("Found %d labels", len(labels))
 
         if self.split_by_label:
@@ -45,7 +46,7 @@ class Exporter:
 
 def create_calendar():
     """Create a new iCalendar object with standard properties."""
-    cal = Calendar()
+    cal = ICalendar()
     cal.add("prodid", f"-//TimeTree Exporter {version('timetree_exporter')}//EN")
     cal.add("version", "2.0")
     return cal


### PR DESCRIPTION
## Summary
- Split CLI parsing, export workflow, selected calendar domain logic, and developer diagnostics into focused modules.
- Centralized developer raw response handling in the API layer so diagnostic output follows the endpoints actually called.
- Simplified `__main__.py` to orchestration while preserving export output behavior.

## Validation
- `uv run ruff check timetree_exporter tests`
- `uv run pytest`
- Compared exports from `origin/main` and `refactor/modulize`; `.ics` output matched after normalizing runtime `DTSTAMP` values.