### PR TITLE
feat: support public calendar exports

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,6 +74,7 @@ Implementation notes:
 - Public API pagination uses `paging.next` and `paging.next_cursor`; when `next` is true, fetch the next page with `cursor=<next_cursor>`.
 - Public events are normalized by `TimeTreePublicEvent`, which extends `TimeTreeEvent`.
 - Public events may omit `uuid`, `type`, `category`, `alerts`, and `recurrences`.
+- Public recurring events may provide a separate `until_at`; use it as RRULE `UNTIL` when the recurrence itself has no `UNTIL`.
 - Public labels are synthesized from `public_calendar_label` because the private labels endpoint is not used.
 
 Useful public calendar checks:
@@ -167,7 +168,7 @@ Public TimeTree event fields:
 - [ ] **Campaign**
 - [ ] **Interest Count**
 - [ ] **Publish At**
-- [ ] **Until At**
+- [x] **Until At** → recurrence `UNTIL` fallback
 - [ ] **Status**
 - [ ] **Region Timezone**
 - [ ] **Location Access**

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -75,7 +75,9 @@ Implementation notes:
 - Public events are normalized by `TimeTreePublicEvent`, which extends `TimeTreeEvent`.
 - Public events may omit `uuid`, `type`, `category`, `alerts`, and `recurrences`.
 - Public recurring events may provide a separate `until_at`; use it as RRULE `UNTIL` when the recurrence itself has no `UNTIL`.
-- Public labels are synthesized from `public_calendar_label` because the private labels endpoint is not used.
+- Public labels are read from public calendar metadata at `/api/v2/public_calendars/{calendar_id}`.
+- Public event payloads still provide `public_calendar_label`, which is used as a fallback during export if metadata labels are unavailable.
+- `--public-calendar --list-labels` reads metadata labels without fetching public events.
 
 Useful public calendar checks:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -171,7 +171,7 @@ Public TimeTree event fields:
 - [ ] ~~**Campaign**~~ (Not mapped; TimeTree campaign metadata has no clear iCalendar equivalent)
 - [ ] ~~**Interest Count**~~ (Not mapped; social metric has no iCalendar equivalent)
 - [ ] ~~**Publish At**~~ (Not mapped; publication metadata is not the event schedule)
-- [x] **Until At** → recurrence `UNTIL` fallback
+- [ ] ~~**Until At**~~ (Not mapped; public events use it as a broad event/recurrence horizon, and RFC 5545 allows unbounded `RRULE`s)
 - [ ] ~~**Status**~~ (Not mapped; TimeTree-specific publication/status metadata)
 - [ ] ~~**Region Timezone**~~ (Not mapped; event times use `start_timezone` and `end_timezone`)
 - [ ] ~~**Location Access**~~ (Not mapped; no clear iCalendar property or parameter)
@@ -180,3 +180,5 @@ Public TimeTree event fields:
 - [ ] ~~**Period Note**~~ (Not mapped; no clear iCalendar property without mixing it into `DESCRIPTION`)
 
 Observed public calendars such as `rakuten_official` and `niigatacity` usually leave `headline` and `overview` empty and put event details in `note`. Public event `DESCRIPTION` is therefore sourced from `note` only, with video URLs appended when present.
+
+`until_at` is present on public one-off events as well as recurring events, so it is not mapped. Public calendars also use 60-year `until_at` horizons for recurring events that have no explicit end date. RFC 5545 allows unbounded `RRULE`s, so these are exported without synthesizing an `UNTIL`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,6 +71,7 @@ Implementation notes:
 - Public events are fetched from `/api/v2/public_calendars/{calendar_id}/public_events`.
 - The request includes `from=0`; without it, TimeTree may return only a short default window.
 - Public API responses use `public_events`, not `events`.
+- Public API pagination uses `paging.next` and `paging.next_cursor`; when `next` is true, fetch the next page with `cursor=<next_cursor>`.
 - Public events are normalized by `TimeTreePublicEvent`, which extends `TimeTreeEvent`.
 - Public events may omit `uuid`, `type`, `category`, `alerts`, and `recurrences`.
 - Public labels are synthesized from `public_calendar_label` because the private labels endpoint is not used.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,6 +55,33 @@ Use `--developer-mode` to write raw TimeTree API responses to `raw-timetree/`.
 
 Use `--raw-output-dir <dir>` to write raw responses to a custom directory.
 
+### Public Calendar Diagnostics
+
+Public calendars use TimeTree API v2 and do not require login:
+
+```bash
+uv run timetree-exporter --public-calendar -c rakuten_official \
+  --developer-mode \
+  --raw-output-dir raw-timetree/public \
+  -o /tmp/rakuten_official.ics
+```
+
+Implementation notes:
+
+- Public events are fetched from `/api/v2/public_calendars/{calendar_id}/public_events`.
+- The request includes `from=0`; without it, TimeTree may return only a short default window.
+- Public API responses use `public_events`, not `events`.
+- Public events are normalized by `TimeTreePublicEvent`, which extends `TimeTreeEvent`.
+- Public events may omit `uuid`, `type`, `category`, `alerts`, and `recurrences`.
+- Public labels are synthesized from `public_calendar_label` because the private labels endpoint is not used.
+
+Useful public calendar checks:
+
+```bash
+uv run pytest tests/test_calendar.py tests/test_event.py tests/test_main.py
+uv run ruff check
+```
+
 ## Before Opening A PR
 
 Run these checks:
@@ -65,6 +92,8 @@ uv run pre-commit run --all-files
 ```
 
 ## Roadmap of the properties mapping to iCal
+
+Private TimeTree event fields:
 
 - [ ] **ID**
 - [ ] **Primary ID**
@@ -102,3 +131,45 @@ uv run pre-commit run --all-files
 - [ ] **Pinned At**
 - [x] **Updated At**
 - [x] **Created At**
+
+Public TimeTree event fields:
+
+- [x] **ID** → `UID`
+- [x] **Title** → `SUMMARY`
+- [x] **All Day** → all-day `DTSTART` / `DTEND`
+- [x] **Start At** → `DTSTART`
+- [x] **Start Timezone** → `DTSTART` timezone
+- [x] **End At** → `DTEND`
+- [x] **End Timezone** → `DTEND` timezone
+- [x] **Created At** → `CREATED`
+- [x] **Updated At** → `LAST-MODIFIED`
+- [x] **URL** → `URL`
+- [x] **Note** → `DESCRIPTION`
+- [x] **Headline** → `DESCRIPTION`
+- [x] **Overview** → `DESCRIPTION`
+- [x] **Link URL** → `DESCRIPTION`
+- [x] **Attachment OGP Title** → `DESCRIPTION`
+- [x] **Attachment OGP Description** → `DESCRIPTION`
+- [x] **Attachment OGP URL** → `DESCRIPTION`
+- [x] **Location Name** → `LOCATION`
+- [x] **Location Address** → `LOCATION`
+- [x] **Location Latitude** → `GEO`
+- [x] **Location Longitude** → `GEO`
+- [x] **Location URL** → `DESCRIPTION`
+- [x] **Public Calendar Label ID** → internal label grouping
+- [x] **Public Calendar Label Name** → `CATEGORIES`
+- [x] **Public Calendar Label Color** → `COLOR`
+- [x] **Top-Level Color** → `COLOR` fallback
+- [x] **Public Calendar Hashtags** → `CATEGORIES`
+- [x] **Cover Image URLs** → `DESCRIPTION`
+- [x] **Video URLs** → `DESCRIPTION`
+- [ ] **Campaign**
+- [ ] **Interest Count**
+- [ ] **Publish At**
+- [ ] **Until At**
+- [ ] **Status**
+- [ ] **Region Timezone**
+- [ ] **Location Access**
+- [ ] **Location Note**
+- [ ] **Period Closed**
+- [ ] **Period Note**

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -147,33 +147,36 @@ Public TimeTree event fields:
 - [x] **End Timezone** → `DTEND` timezone
 - [x] **Created At** → `CREATED`
 - [x] **Updated At** → `LAST-MODIFIED`
-- [x] **URL** → `URL`
+- [x] **URL** → `SOURCE`
 - [x] **Note** → `DESCRIPTION`
-- [x] **Headline** → `DESCRIPTION`
-- [x] **Overview** → `DESCRIPTION`
-- [x] **Link URL** → `DESCRIPTION`
-- [x] **Attachment OGP Title** → `DESCRIPTION`
-- [x] **Attachment OGP Description** → `DESCRIPTION`
-- [x] **Attachment OGP URL** → `DESCRIPTION`
+- [ ] ~~**Headline**~~ (Not mapped; observed public calendars leave it empty, and `SUMMARY` already uses `title`)
+- [ ] ~~**Overview**~~ (Not mapped; observed public calendars leave it empty, and `DESCRIPTION` uses `note`)
+- [x] **Link URL** → `URL`
+- [ ] ~~**Attachment OGP Title**~~ (Not mapped; no clear iCalendar property beyond duplicating `SUMMARY`/`DESCRIPTION`)
+- [ ] ~~**Attachment OGP Description**~~ (Not mapped; no clear iCalendar property beyond duplicating `DESCRIPTION`)
+- [ ] ~~**Attachment OGP URL**~~ (Not mapped; `link_url` already maps to `URL`)
 - [x] **Location Name** → `LOCATION`
 - [x] **Location Address** → `LOCATION`
 - [x] **Location Latitude** → `GEO`
 - [x] **Location Longitude** → `GEO`
-- [x] **Location URL** → `DESCRIPTION`
+- [x] **Location URL** → `LOCATION;ALTREP`
 - [x] **Public Calendar Label ID** → internal label grouping
 - [x] **Public Calendar Label Name** → `CATEGORIES`
 - [x] **Public Calendar Label Color** → `COLOR`
 - [x] **Top-Level Color** → `COLOR` fallback
 - [x] **Public Calendar Hashtags** → `CATEGORIES`
-- [x] **Cover Image URLs** → `DESCRIPTION`
+- [x] **Cover Image URLs** → `IMAGE;DISPLAY=FULLSIZE`
+- [x] **Cover Thumbnail Image URLs** → `IMAGE;DISPLAY=THUMBNAIL`
 - [x] **Video URLs** → `DESCRIPTION`
-- [ ] **Campaign**
-- [ ] **Interest Count**
-- [ ] **Publish At**
+- [ ] ~~**Campaign**~~ (Not mapped; TimeTree campaign metadata has no clear iCalendar equivalent)
+- [ ] ~~**Interest Count**~~ (Not mapped; social metric has no iCalendar equivalent)
+- [ ] ~~**Publish At**~~ (Not mapped; publication metadata is not the event schedule)
 - [x] **Until At** → recurrence `UNTIL` fallback
-- [ ] **Status**
-- [ ] **Region Timezone**
-- [ ] **Location Access**
-- [ ] **Location Note**
-- [ ] **Period Closed**
-- [ ] **Period Note**
+- [ ] ~~**Status**~~ (Not mapped; TimeTree-specific publication/status metadata)
+- [ ] ~~**Region Timezone**~~ (Not mapped; event times use `start_timezone` and `end_timezone`)
+- [ ] ~~**Location Access**~~ (Not mapped; no clear iCalendar property or parameter)
+- [ ] ~~**Location Note**~~ (Not mapped; no clear iCalendar property without mixing it into `DESCRIPTION`)
+- [ ] ~~**Period Closed**~~ (Not mapped; no clear iCalendar property or parameter)
+- [ ] ~~**Period Note**~~ (Not mapped; no clear iCalendar property without mixing it into `DESCRIPTION`)
+
+Observed public calendars such as `rakuten_official` and `niigatacity` usually leave `headline` and `overview` empty and put event details in `note`. Public event `DESCRIPTION` is therefore sourced from `note` only, with video URLs appended when present.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Then, you can import the ics file to your calendar app.
 
     Note: Find the calendar code in the URL of the calendar page or when running the script without the `-c` option.
 
+- Export a public calendar by id without signing in.
+
+    ```bash
+    timetree-exporter --public-calendar -c public_calendar_id
+    ```
+
+    Note: Public calendar events use TimeTree's public API and may not include labels, alerts, recurrences, or UUIDs.
+
 - You can pass your email address and password with environment variables. (usually for automation purposes)
 
   ```bash

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Downloads](https://img.shields.io/pypi/dm/timetree-exporter)](https://pypistats.org/packages/timetree-exporter)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-Donate-orange.svg?logo=buymeacoffee&logoColor=white)](https://www.buymeacoffee.com/eoleedi)
 
-A Tool for Exporting TimeTree Calendar and Converting to iCal Format (.ics) ([RFC 5545](http://tools.ietf.org/html/rfc5545.html) Compatible) \
+A Tool for Exporting TimeTree Calendar and Converting to iCalendar Format (.ics) ([RFC 5545](https://datatracker.ietf.org/doc/html/rfc5545) compatible, with selected [RFC 7986](https://datatracker.ietf.org/doc/html/rfc7986) properties) \
 This script works by scraping the TimeTree web app and converting the data to iCal format.
 (The .ics file can then be imported into other calendar apps such as Google Calendar, Apple Calendar, Outlook Calendar, etc.)
 
@@ -68,6 +68,7 @@ Then, you can import the ics file to your calendar app.
     ```
 
     Note: Public calendar events use TimeTree's public API and may not include labels, alerts, recurrences, or UUIDs.
+    Public calendar metadata such as source links, images, and colors is exported with RFC 7986 properties like `SOURCE`, `IMAGE`, and `COLOR` when available. Calendar apps that only implement RFC 5545 may ignore these optional fields.
 
 - You can pass your email address and password with environment variables. (usually for automation purposes)
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -23,6 +23,18 @@ class _FakeSession:
         return _FakeResponse(self._payload)
 
 
+class _RecordingSession(_FakeSession):
+    def __init__(self, payload):
+        super().__init__(payload)
+        self.requested_url = None
+        self.requested_params = None
+
+    def get(self, url, **kwargs):
+        self.requested_url = url
+        self.requested_params = kwargs.get("params")
+        return _FakeResponse(self._payload)
+
+
 def _calendar_with_metadata_response(payload, capture_raw_responses=True):
     calendar = TimeTreeCalendar("dummy-session-id", capture_raw_responses=capture_raw_responses)
     calendar.session = _FakeSession(payload)
@@ -92,3 +104,32 @@ def test_api_calls_write_raw_responses_when_developer_output_is_configured(tmp_p
     assert (tmp_path / "01_calendars.json").exists()
     assert (tmp_path / "calendar_1/02_labels.json").exists()
     assert not (tmp_path / "calendar_1/03_events_sync.json").exists()
+
+
+def test_get_public_events_uses_public_calendar_endpoint():
+    """Public calendar exports should use the API v2 public_events endpoint."""
+    calendar = TimeTreeCalendar("dummy-session-id")
+    session = _RecordingSession({"public_events": [{"id": "public-event-id"}]})
+    calendar.session = session
+
+    events = calendar.get_public_events("public-calendar-id", "Public Calendar")
+
+    assert session.requested_url.endswith(
+        "/api/v2/public_calendars/public-calendar-id/public_events"
+    )
+    assert session.requested_params == {"from": 0}
+    assert events == [{"id": "public-event-id"}]
+
+
+def test_raw_public_event_response_filename_includes_calendar_id(tmp_path):
+    """Raw public event response filenames should identify the selected public calendar."""
+    configure_developer_mode(raw_output_dir=tmp_path)
+
+    try:
+        calendar = TimeTreeCalendar("dummy-session-id")
+        calendar.session = _FakeSession({"public_events": []})
+        calendar.get_public_events("public-calendar-id", "Public Calendar")
+    finally:
+        configure_developer_mode()
+
+    assert (tmp_path / "public_calendar_public-calendar-id/01_public_events.json").exists()

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -35,6 +35,16 @@ class _RecordingSession(_FakeSession):
         return _FakeResponse(self._payload)
 
 
+class _PagingSession:
+    def __init__(self, payloads):
+        self._payloads = list(payloads)
+        self.requested_params = []
+
+    def get(self, _url, **kwargs):
+        self.requested_params.append(kwargs.get("params"))
+        return _FakeResponse(self._payloads.pop(0))
+
+
 def _calendar_with_metadata_response(payload, capture_raw_responses=True):
     calendar = TimeTreeCalendar("dummy-session-id", capture_raw_responses=capture_raw_responses)
     calendar.session = _FakeSession(payload)
@@ -119,6 +129,32 @@ def test_get_public_events_uses_public_calendar_endpoint():
     )
     assert session.requested_params == {"from": 0}
     assert events == [{"id": "public-event-id"}]
+
+
+def test_get_public_events_follows_pagination_cursor():
+    """Public calendar exports should follow the public_events paging envelope."""
+    calendar = TimeTreeCalendar("dummy-session-id")
+    session = _PagingSession(
+        [
+            {
+                "public_events": [{"id": "first-event"}],
+                "paging": {"next": True, "next_cursor": "next-page"},
+            },
+            {
+                "public_events": [{"id": "second-event"}],
+                "paging": {"next": False},
+            },
+        ]
+    )
+    calendar.session = session
+
+    events = calendar.get_public_events("public-calendar-id", "Public Calendar")
+
+    assert session.requested_params == [
+        {"from": 0},
+        {"from": 0, "cursor": "next-page"},
+    ]
+    assert events == [{"id": "first-event"}, {"id": "second-event"}]
 
 
 def test_raw_public_event_response_filename_includes_calendar_id(tmp_path):

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -101,6 +101,22 @@ def test_get_public_labels_uses_public_calendar_metadata_endpoint():
     assert labels == {4: {"name": "Public Campaign", "color": "#948078"}}
 
 
+def test_parse_public_labels_skips_missing_id_and_coerces_name():
+    """Malformed public labels should not create None keys, and names should be strings."""
+    labels = TimeTreeCalendar._parse_public_labels(
+        {
+            "public_calendar": {
+                "public_calendar_labels": [
+                    {"name": "Missing ID", "color": 0},
+                    {"label_id": 0, "name": None, "color": 0},
+                ]
+            }
+        }
+    )
+
+    assert labels == {0: {"name": "", "color": "#000000"}}
+
+
 def test_raw_responses_are_not_recorded_by_default():
     """Raw payloads should only be retained when developer mode enables capture."""
     calendar = _calendar_with_metadata_response({"calendars": []}, capture_raw_responses=False)

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -80,6 +80,27 @@ def test_raw_label_response_filename_includes_calendar_id(tmp_path):
     assert (tmp_path / "calendar_1/01_labels.json").exists()
 
 
+def test_get_public_labels_uses_public_calendar_metadata_endpoint():
+    """Public calendar labels should come from metadata, not event payloads."""
+    calendar = TimeTreeCalendar("dummy-session-id")
+    session = _RecordingSession(
+        {
+            "public_calendar": {
+                "public_calendar_labels": [
+                    {"label_id": 4, "name": "Public Campaign", "color": 9732216}
+                ]
+            }
+        }
+    )
+    calendar.session = session
+
+    labels = calendar.get_public_labels("public-calendar-id")
+
+    assert session.requested_url.endswith("/api/v2/public_calendars/public-calendar-id")
+    assert session.requested_params is None
+    assert labels == {4: {"name": "Public Campaign", "color": "#948078"}}
+
+
 def test_raw_responses_are_not_recorded_by_default():
     """Raw payloads should only be retained when developer mode enables capture."""
     calendar = _calendar_with_metadata_response({"calendars": []}, capture_raw_responses=False)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -4,6 +4,7 @@ from timetree_exporter.event import (
     TimeTreeEvent,
     TimeTreeEventCategory,
     TimeTreeEventType,
+    TimeTreePublicEvent,
 )
 
 
@@ -111,3 +112,57 @@ def test_from_dict_without_label(normal_event_data):
     """Test that label_id is None when no label data is present."""
     event = TimeTreeEvent.from_dict(normal_event_data)
     assert event.label_id is None
+
+
+def test_public_event_from_dict_maps_public_api_fields(normal_event_data):
+    """Public calendar events should normalize API v2 fields to TimeTreeEvent fields."""
+    public_event_data = normal_event_data.copy()
+    public_event_data.pop("uuid")
+    public_event_data.pop("type")
+    public_event_data.pop("category")
+    public_event_data.pop("location")
+    public_event_data["id"] = "public-event-id"
+    public_event_data["location_name"] = "Public Venue"
+    public_event_data["location_address"] = "1 Public Street"
+    public_event_data["headline"] = "Public headline"
+    public_event_data["overview"] = "Public overview"
+    public_event_data["link_url"] = "https://example.com/campaign"
+    public_event_data["location_url"] = "https://example.com/location"
+    public_event_data["attachment"] = {
+        "ogp": {
+            "title": "OGP title",
+            "description": "OGP description",
+            "url": "https://example.com/ogp",
+        }
+    }
+    public_event_data["images"] = {"cover": [{"url": "https://example.com/image.jpg"}]}
+    public_event_data["videos"] = [{"url": "https://example.com/video.mp4"}]
+    public_event_data["public_calendar_hashtags"] = [
+        {"name": "Shopping"},
+        {"hashtag": "Sale"},
+        "Rakuten",
+    ]
+    public_event_data["public_calendar_label"] = {
+        "label_id": 9,
+        "name": "Campaign",
+    }
+    public_event_data["color"] = 9732216
+
+    event = TimeTreePublicEvent.from_dict(public_event_data)
+
+    assert event.uuid == "public-event-id"
+    assert event.location == "Public Venue 1 Public Street"
+    assert event.event_type == TimeTreeEventType.NORMAL
+    assert event.category == TimeTreeEventCategory.NORMAL
+    assert event.label_id == 9
+    assert event.label_name == "Campaign"
+    assert event.label_color == "#948078"
+    assert event.category_names == ["Shopping", "Sale", "Rakuten"]
+    assert event.link_url == "https://example.com/campaign"
+    assert event.location_url == "https://example.com/location"
+    assert event.image_urls == ["https://example.com/image.jpg"]
+    assert event.video_urls == ["https://example.com/video.mp4"]
+    assert "Public headline" in event.note
+    assert "Public overview" in event.note
+    assert "Link title: OGP title" in event.note
+    assert "Link: https://example.com/campaign" in event.note

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -166,3 +166,21 @@ def test_public_event_from_dict_maps_public_api_fields(normal_event_data):
     assert "Public overview" in event.note
     assert "Link title: OGP title" in event.note
     assert "Link: https://example.com/campaign" in event.note
+
+
+def test_public_event_from_dict_preserves_zero_label_values(normal_event_data):
+    """Public event parsing should treat zero color and label id as real values."""
+    public_event_data = normal_event_data.copy()
+    public_event_data.pop("uuid")
+    public_event_data["id"] = "public-event-id"
+    public_event_data["color"] = 9732216
+    public_event_data["public_calendar_label"] = {
+        "label_id": 0,
+        "name": "Black",
+        "color": 0,
+    }
+
+    event = TimeTreePublicEvent.from_dict(public_event_data)
+
+    assert event.label_id == 0
+    assert event.label_color == "#000000"

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -126,6 +126,7 @@ def test_public_event_from_dict_maps_public_api_fields(normal_event_data):
     public_event_data["location_address"] = "1 Public Street"
     public_event_data["headline"] = "Public headline"
     public_event_data["overview"] = "Public overview"
+    public_event_data["url"] = "https://timetr.ee/p/public-event-id"
     public_event_data["link_url"] = "https://example.com/campaign"
     public_event_data["location_url"] = "https://example.com/location"
     public_event_data["attachment"] = {
@@ -135,7 +136,14 @@ def test_public_event_from_dict_maps_public_api_fields(normal_event_data):
             "url": "https://example.com/ogp",
         }
     }
-    public_event_data["images"] = {"cover": [{"url": "https://example.com/image.jpg"}]}
+    public_event_data["images"] = {
+        "cover": [
+            {
+                "url": "https://example.com/image.jpg",
+                "thumbnail_url": "https://example.com/thumb.jpg",
+            }
+        ]
+    }
     public_event_data["videos"] = [{"url": "https://example.com/video.mp4"}]
     public_event_data["public_calendar_hashtags"] = [
         {"name": "Shopping"},
@@ -158,14 +166,21 @@ def test_public_event_from_dict_maps_public_api_fields(normal_event_data):
     assert event.label_name == "Campaign"
     assert event.label_color == "#948078"
     assert event.category_names == ["Shopping", "Sale", "Rakuten"]
+    assert event.url == "https://example.com/campaign"
+    assert event.source_url == "https://timetr.ee/p/public-event-id"
     assert event.link_url == "https://example.com/campaign"
     assert event.location_url == "https://example.com/location"
     assert event.image_urls == ["https://example.com/image.jpg"]
+    assert event.thumbnail_image_urls == ["https://example.com/thumb.jpg"]
     assert event.video_urls == ["https://example.com/video.mp4"]
-    assert "Public headline" in event.note
-    assert "Public overview" in event.note
-    assert "Link title: OGP title" in event.note
-    assert "Link: https://example.com/campaign" in event.note
+    assert "Public headline" not in event.note
+    assert "Public overview" not in event.note
+    assert "OGP title" not in event.note
+    assert "OGP description" not in event.note
+    assert "https://example.com/ogp" not in event.note
+    assert "https://timetr.ee/p/public-event-id" not in event.note
+    assert "https://example.com/image.jpg" not in event.note
+    assert "https://example.com/location" not in event.note
 
 
 def test_public_event_from_dict_preserves_zero_label_values(normal_event_data):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -236,6 +236,25 @@ def test_public_recurrence_uses_until_at_when_rrule_has_no_until(normal_event_da
     assert ical_event["RRULE"]["UNTIL"] == [datetime(2024, 9, 1, tzinfo=ZoneInfo("UTC"))]
 
 
+def test_public_recurrence_preserves_zero_until_at(normal_event_data):
+    """Public until_at=0 should be treated as a valid recurrence bound."""
+    data = normal_event_data.copy()
+    data.pop("uuid")
+    data.update(
+        {
+            "id": "public-event-id",
+            "recurrences": ["RRULE:FREQ=MONTHLY"],
+            "until_at": 0,
+        }
+    )
+
+    event = TimeTreePublicEvent.from_dict(data)
+    formatter = ICalEventFormatter(event)
+    ical_event = formatter.to_ical()
+
+    assert ical_event["RRULE"]["UNTIL"] == [datetime(1970, 1, 1, tzinfo=ZoneInfo("UTC"))]
+
+
 def test_no_alarms_location_url(normal_event_data):
     """Test event formatting without optional fields."""
     # Create an event without alarms, location, and URL

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -297,6 +297,78 @@ def test_categories_with_additional_category_names(normal_event_data):
     assert ical_event["CATEGORIES"].cats == ["Work", "Sale", "Food"]
 
 
+def test_public_images_are_exported_as_image_properties(normal_event_data):
+    """Public cover images should be exported as RFC 7986 IMAGE properties."""
+    data = normal_event_data.copy()
+    data.pop("uuid")
+    data["id"] = "public-event-id"
+    data["images"] = {
+        "cover": [
+            {
+                "url": "https://example.com/image.jpg",
+                "thumbnail_url": "https://example.com/thumb.jpg",
+            }
+        ]
+    }
+
+    event = TimeTreePublicEvent.from_dict(data)
+    formatter = ICalEventFormatter(event)
+    ical_event = formatter.to_ical()
+    serialized = ical_event.to_ical().decode()
+
+    assert "IMAGE;DISPLAY=FULLSIZE;VALUE=URI:https://example.com/image.jpg" in serialized
+    assert "IMAGE;DISPLAY=THUMBNAIL;VALUE=URI:https://example.com/thumb.jpg" in serialized
+
+
+def test_public_location_url_is_exported_as_location_altrep(normal_event_data):
+    """Public location URLs should be exported as LOCATION ALTREP."""
+    data = normal_event_data.copy()
+    data.pop("uuid")
+    data["id"] = "public-event-id"
+    data["location"] = "Public Venue"
+    data["location_url"] = "https://example.com/location"
+
+    event = TimeTreePublicEvent.from_dict(data)
+    formatter = ICalEventFormatter(event)
+    ical_event = formatter.to_ical()
+
+    assert ical_event["LOCATION"] == "Public Venue"
+    assert ical_event["LOCATION"].params["ALTREP"] == "https://example.com/location"
+
+
+def test_public_event_uses_link_url_as_ical_url_and_timetree_url_as_source(normal_event_data):
+    """Public campaign links should be URL, while TimeTree permalinks are SOURCE."""
+    data = normal_event_data.copy()
+    data.pop("uuid")
+    data["id"] = "public-event-id"
+    data["url"] = "https://timetr.ee/p/public-event-id"
+    data["link_url"] = "https://example.com/campaign"
+
+    event = TimeTreePublicEvent.from_dict(data)
+    formatter = ICalEventFormatter(event)
+    ical_event = formatter.to_ical()
+
+    assert ical_event["URL"] == "https://example.com/campaign"
+    assert ical_event["SOURCE"] == "https://timetr.ee/p/public-event-id"
+    assert ical_event["SOURCE"].params["VALUE"] == "URI"
+
+
+def test_public_event_without_link_url_has_source_but_no_ical_url(normal_event_data):
+    """Public TimeTree permalinks should not become URL when link_url is absent."""
+    data = normal_event_data.copy()
+    data.pop("uuid")
+    data.pop("url")
+    data["id"] = "public-event-id"
+    data["url"] = "https://timetr.ee/p/public-event-id"
+
+    event = TimeTreePublicEvent.from_dict(data)
+    formatter = ICalEventFormatter(event)
+    ical_event = formatter.to_ical()
+
+    assert "URL" not in ical_event
+    assert ical_event["SOURCE"] == "https://timetr.ee/p/public-event-id"
+
+
 def test_different_timezones(normal_event_data):
     """Test event with different start and end timezones."""
     # Create an event with different start and end timezones

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -9,6 +9,7 @@ from icalendar.prop import vDuration
 from timetree_exporter.event import (
     TimeTreeEvent,
     TimeTreeEventType,
+    TimeTreePublicEvent,
 )
 from timetree_exporter.formatter import ICalEventFormatter
 from timetree_exporter.utils import convert_timestamp_to_datetime
@@ -214,6 +215,25 @@ def test_rrule_until_date_for_all_day_event_stays_date(normal_event_data):
     ical_event = formatter.to_ical()
 
     assert ical_event["RRULE"]["UNTIL"] == [date(2022, 5, 24)]
+
+
+def test_public_recurrence_uses_until_at_when_rrule_has_no_until(normal_event_data):
+    """Public recurring events should use until_at to avoid unbounded recurrence."""
+    data = normal_event_data.copy()
+    data.pop("uuid")
+    data.update(
+        {
+            "id": "public-event-id",
+            "recurrences": ["RRULE:FREQ=MONTHLY"],
+            "until_at": int(datetime(2024, 9, 1, tzinfo=ZoneInfo("UTC")).timestamp() * 1000),
+        }
+    )
+
+    event = TimeTreePublicEvent.from_dict(data)
+    formatter = ICalEventFormatter(event)
+    ical_event = formatter.to_ical()
+
+    assert ical_event["RRULE"]["UNTIL"] == [datetime(2024, 9, 1, tzinfo=ZoneInfo("UTC"))]
 
 
 def test_no_alarms_location_url(normal_event_data):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -217,15 +217,15 @@ def test_rrule_until_date_for_all_day_event_stays_date(normal_event_data):
     assert ical_event["RRULE"]["UNTIL"] == [date(2022, 5, 24)]
 
 
-def test_public_recurrence_uses_until_at_when_rrule_has_no_until(normal_event_data):
-    """Public recurring events should use until_at to avoid unbounded recurrence."""
+def test_public_recurrence_does_not_map_until_at(normal_event_data):
+    """Public until_at should not synthesize recurrence bounds."""
     data = normal_event_data.copy()
     data.pop("uuid")
     data.update(
         {
             "id": "public-event-id",
             "recurrences": ["RRULE:FREQ=MONTHLY"],
-            "until_at": int(datetime(2024, 9, 1, tzinfo=ZoneInfo("UTC")).timestamp() * 1000),
+            "until_at": int(datetime(2085, 4, 1, tzinfo=ZoneInfo("UTC")).timestamp() * 1000),
         }
     )
 
@@ -233,18 +233,40 @@ def test_public_recurrence_uses_until_at_when_rrule_has_no_until(normal_event_da
     formatter = ICalEventFormatter(event)
     ical_event = formatter.to_ical()
 
-    assert ical_event["RRULE"]["UNTIL"] == [datetime(2024, 9, 1, tzinfo=ZoneInfo("UTC"))]
+    assert ical_event["RRULE"]["FREQ"] == ["MONTHLY"]
+    assert "UNTIL" not in ical_event["RRULE"]
 
 
-def test_public_recurrence_preserves_zero_until_at(normal_event_data):
-    """Public until_at=0 should be treated as a valid recurrence bound."""
+def test_rrule_rejects_count_with_until(normal_event_data):
+    """RRULEs with both COUNT and UNTIL should fail loudly."""
+    data = normal_event_data.copy()
+    data.update(
+        {
+            "recurrences": ["RRULE:FREQ=DAILY;UNTIL=20251130;COUNT=3;INTERVAL=7"],
+            "all_day": True,
+        }
+    )
+
+    event = TimeTreeEvent.from_dict(data)
+    formatter = ICalEventFormatter(event)
+
+    try:
+        formatter.to_ical()
+    except ValueError as exc:
+        assert str(exc) == "RRULE must not include both COUNT and UNTIL"
+    else:
+        raise AssertionError("expected invalid RRULE to raise ValueError")
+
+
+def test_public_until_at_is_not_added_when_count_is_present(normal_event_data):
+    """Public until_at should not create invalid COUNT plus UNTIL rules."""
     data = normal_event_data.copy()
     data.pop("uuid")
     data.update(
         {
             "id": "public-event-id",
-            "recurrences": ["RRULE:FREQ=MONTHLY"],
-            "until_at": 0,
+            "recurrences": ["RRULE:FREQ=DAILY;COUNT=1;INTERVAL=14"],
+            "until_at": int(datetime(2025, 12, 11, tzinfo=ZoneInfo("UTC")).timestamp() * 1000),
         }
     )
 
@@ -252,7 +274,8 @@ def test_public_recurrence_preserves_zero_until_at(normal_event_data):
     formatter = ICalEventFormatter(event)
     ical_event = formatter.to_ical()
 
-    assert ical_event["RRULE"]["UNTIL"] == [datetime(1970, 1, 1, tzinfo=ZoneInfo("UTC"))]
+    assert ical_event["RRULE"]["COUNT"] == [1]
+    assert "UNTIL" not in ical_event["RRULE"]
 
 
 def test_no_alarms_location_url(normal_event_data):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -249,7 +249,7 @@ def test_categories_with_label_name(normal_event_data):
     """Test that CATEGORIES is set when label_name is provided."""
     event = TimeTreeEvent.from_dict(normal_event_data)
     formatter = ICalEventFormatter(event, label_name="Work")
-    assert formatter.categories == "Work"
+    assert formatter.categories == ["Work"]
 
     ical_event = formatter.to_ical()
     assert "CATEGORIES" in ical_event
@@ -264,6 +264,17 @@ def test_categories_without_label_name(normal_event_data):
 
     ical_event = formatter.to_ical()
     assert "CATEGORIES" not in ical_event
+
+
+def test_categories_with_additional_category_names(normal_event_data):
+    """Test that additional public category names are included in CATEGORIES."""
+    event = TimeTreeEvent.from_dict(normal_event_data)
+    formatter = ICalEventFormatter(event, label_name="Work", category_names=["Sale", "Food"])
+
+    assert formatter.categories == ["Work", "Sale", "Food"]
+
+    ical_event = formatter.to_ical()
+    assert ical_event["CATEGORIES"].cats == ["Work", "Sale", "Food"]
 
 
 def test_different_timezones(normal_event_data):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -264,6 +264,21 @@ def test_public_labels_preserve_zero_label_color():
     assert labels == {4: {"name": "Black", "color": "#000000"}}
 
 
+def test_public_labels_from_events_coerces_label_names():
+    """Fallback public labels should always use string names."""
+    labels = public_labels_from_events(
+        [
+            {"public_calendar_label": {"label_id": 4, "name": None, "color": 0}},
+            {"public_calendar_label": {"label_id": 5, "name": 123, "color": 0}},
+        ]
+    )
+
+    assert labels == {
+        4: {"name": "", "color": "#000000"},
+        5: {"name": "123", "color": "#000000"},
+    }
+
+
 def test_developer_mode_globally_enables_raw_output():
     """Developer mode should be readable globally by modules."""
     configure_developer_mode(enabled=True)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,6 +16,7 @@ from timetree_exporter.exporter import (
     Exporter,
     create_calendar,
     label_suffix_for_group,
+    public_labels_from_events,
     write_calendar,
 )
 from timetree_exporter.formatter import ICalEventFormatter
@@ -44,6 +45,12 @@ class _FakeExportCalendarApi:
     def get_labels(self, calendar_id):
         self.fetched_labels_for = calendar_id
         return self.labels
+
+
+class _FakePublicCalendarApi(_FakeExportCalendarApi):
+    def get_public_events(self, calendar_id, calendar_name):
+        self.fetched_events_for = (calendar_id, calendar_name)
+        return self.events
 
 
 class _Args:
@@ -164,6 +171,54 @@ def test_exporter_writes_split_calendars_by_label(tmp_path, labeled_event_data):
     serialized = split_path.read_text(encoding="utf-8")
     assert not output_path.exists()
     assert "SUMMARY:測試有標籤活動" in serialized
+
+
+def test_public_calendar_fetches_public_events_and_skips_labels(tmp_path, normal_event_data):
+    """Public calendars should export public_events without calling the labels endpoint."""
+    public_event_data = normal_event_data.copy()
+    public_event_data.pop("uuid")
+    public_event_data["id"] = "public-event-id"
+    public_event_data["public_calendar_label"] = {
+        "label_id": 4,
+        "name": "Public Campaign",
+        "color": 9732216,
+    }
+    public_event_data["public_calendar_hashtags"] = [{"name": "Shopping"}]
+    api = _FakePublicCalendarApi([public_event_data], {})
+    output_path = tmp_path / "calendar.ics"
+    calendar = Calendar(
+        api,
+        {
+            "id": "public-calendar-id",
+            "name": "Public Calendar",
+            "alias_code": "public-calendar-id",
+            "public": True,
+        },
+    )
+
+    Exporter(calendar, output_path).export()
+
+    serialized = output_path.read_text(encoding="utf-8")
+    assert api.fetched_events_for == ("public-calendar-id", "Public Calendar")
+    assert api.fetched_labels_for is None
+    assert "SUMMARY:測試一般活動" in serialized
+    assert "UID:public-event-id" in serialized
+    assert "CATEGORIES:Public Campaign,Shopping" in serialized
+    assert "COLOR:#948078" in serialized
+
+
+def test_public_labels_use_event_color_when_label_color_is_missing():
+    """Public event top-level color should be used when label color is absent."""
+    labels = public_labels_from_events(
+        [
+            {
+                "color": 9732216,
+                "public_calendar_label": {"label_id": 4, "name": "Public Campaign"},
+            }
+        ]
+    )
+
+    assert labels == {4: {"name": "Public Campaign", "color": "#948078"}}
 
 
 def test_developer_mode_globally_enables_raw_output():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,9 +48,17 @@ class _FakeExportCalendarApi:
 
 
 class _FakePublicCalendarApi(_FakeExportCalendarApi):
+    def __init__(self, events, labels):
+        super().__init__(events, labels)
+        self.fetched_public_labels_for = None
+
     def get_public_events(self, calendar_id, calendar_name):
         self.fetched_events_for = (calendar_id, calendar_name)
         return self.events
+
+    def get_public_labels(self, calendar_id):
+        self.fetched_public_labels_for = calendar_id
+        return self.labels
 
 
 class _Args:
@@ -74,6 +82,26 @@ def test_list_labels_and_exit_handles_invalid_or_missing_color(capsys):
     assert "Empty" in output
     assert "Malformed" in output
     assert "\033[38;2;255;0;170m●\033[0m" in output
+
+
+def test_list_labels_and_exit_uses_public_labels_without_fetching_events(capsys):
+    """Public calendar label listing should not fetch public events."""
+    api = _FakePublicCalendarApi(
+        [{"id": "public-event-id"}],
+        {4: {"name": "Public Campaign", "color": "#948078"}},
+    )
+    calendar = Calendar(
+        api,
+        {"id": "public-calendar-id", "name": "Public Calendar", "public": True},
+    )
+
+    list_labels_and_exit(calendar)
+
+    output = capsys.readouterr().out
+    assert api.fetched_events_for is None
+    assert api.fetched_public_labels_for == "public-calendar-id"
+    assert "Public Campaign" in output
+    assert "No labels found" not in output
 
 
 def test_label_suffix_for_group_uses_label_id_when_name_is_empty():
@@ -201,6 +229,7 @@ def test_public_calendar_fetches_public_events_and_skips_labels(tmp_path, normal
     serialized = output_path.read_text(encoding="utf-8")
     assert api.fetched_events_for == ("public-calendar-id", "Public Calendar")
     assert api.fetched_labels_for is None
+    assert api.fetched_public_labels_for == "public-calendar-id"
     assert "SUMMARY:測試一般活動" in serialized
     assert "UID:public-event-id" in serialized
     assert "CATEGORIES:Public Campaign,Shopping" in serialized

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -250,6 +250,20 @@ def test_public_labels_use_event_color_when_label_color_is_missing():
     assert labels == {4: {"name": "Public Campaign", "color": "#948078"}}
 
 
+def test_public_labels_preserve_zero_label_color():
+    """Public label color 0 should stay black instead of falling back to event color."""
+    labels = public_labels_from_events(
+        [
+            {
+                "color": 9732216,
+                "public_calendar_label": {"label_id": 4, "name": "Black", "color": 0},
+            }
+        ]
+    )
+
+    assert labels == {4: {"name": "Black", "color": "#000000"}}
+
+
 def test_developer_mode_globally_enables_raw_output():
     """Developer mode should be readable globally by modules."""
     configure_developer_mode(enabled=True)

--- a/timetree_exporter/__init__.py
+++ b/timetree_exporter/__init__.py
@@ -4,6 +4,7 @@ import logging
 from importlib.metadata import PackageNotFoundError, version
 
 from timetree_exporter.event import TimeTreeEvent as TimeTreeEvent
+from timetree_exporter.event import TimeTreePublicEvent as TimeTreePublicEvent
 from timetree_exporter.formatter import ICalEventFormatter as ICalEventFormatter
 
 logger = logging.getLogger(__name__)

--- a/timetree_exporter/__main__.py
+++ b/timetree_exporter/__main__.py
@@ -68,15 +68,36 @@ def select_calendar(email: str, password: str, calendar_code: str):
     return Calendar(calendar, metadata)
 
 
+def select_public_calendar(calendar_id: str):
+    """Select a public calendar by id."""
+    if not calendar_id:
+        raise ValueError(
+            "--public-calendar requires -c/--calendar_code with the public calendar id"
+        )
+    calendar = TimeTreeCalendar("")
+    return Calendar(
+        calendar,
+        {
+            "id": calendar_id,
+            "name": f"Public Calendar {calendar_id}",
+            "alias_code": calendar_id,
+            "public": True,
+        },
+    )
+
+
 def main():
     """Main function for the Timetree Exporter."""
     args = parse_args()
     configure_logging(args.verbose)
     configure_developer_mode(args.developer_mode, args.raw_output_dir)
 
-    email = resolve_email(args.email)
-    password = resolve_password()
-    calendar = select_calendar(email, password, args.calendar_code)
+    if args.public_calendar:
+        calendar = select_public_calendar(args.calendar_code)
+    else:
+        email = resolve_email(args.email)
+        password = resolve_password()
+        calendar = select_calendar(email, password, args.calendar_code)
     exporter = Exporter(calendar, args.output, split_by_label=args.split_by_label)
 
     if args.list_labels:

--- a/timetree_exporter/api/calendar.py
+++ b/timetree_exporter/api/calendar.py
@@ -10,10 +10,12 @@ from pathlib import Path
 import requests
 from requests.exceptions import HTTPError
 
-from timetree_exporter.api.const import API_BASEURI, API_USER_AGENT
+from timetree_exporter.api.const import API_BASEURI, API_USER_AGENT, API_V2_BASEURI
 from timetree_exporter.config import get_raw_output_dir
 
 logger = logging.getLogger(__name__)
+
+PUBLIC_EVENTS_FROM = 0
 
 
 class TimeTreeCalendar:
@@ -179,6 +181,35 @@ class TimeTreeCalendar:
 
         logger.debug(
             "Top 5 fetched events: \n %s",
+            json.dumps(events[:5], indent=2, ensure_ascii=False),
+        )
+
+        return events
+
+    def get_public_events(self, calendar_id: int, calendar_name: str = None):
+        """
+        Get events from a public calendar.
+        """
+        url = f"{API_V2_BASEURI}/public_calendars/{calendar_id}/public_events"
+        response = self.session.get(
+            url,
+            headers={"Content-Type": "application/json", "X-Timetreea": API_USER_AGENT},
+            params={"from": PUBLIC_EVENTS_FROM},
+        )
+        if response.status_code != 200:
+            if calendar_name is not None:
+                logger.error("Failed to get events of the public calendar '%s'", calendar_name)
+            else:
+                logger.error("Failed to get events of the public calendar")
+            logger.error(response.text)
+            raise HTTPError("Failed to get public calendar events")
+
+        r_json = response.json()
+        self._record_raw_response(f"public_calendar_{calendar_id}/public_events", r_json)
+        events = r_json["public_events"]
+        logger.info("Fetched %d public events", len(events))
+        logger.debug(
+            "Top 5 fetched public events: \n %s",
             json.dumps(events[:5], indent=2, ensure_ascii=False),
         )
 

--- a/timetree_exporter/api/calendar.py
+++ b/timetree_exporter/api/calendar.py
@@ -191,22 +191,39 @@ class TimeTreeCalendar:
         Get events from a public calendar.
         """
         url = f"{API_V2_BASEURI}/public_calendars/{calendar_id}/public_events"
-        response = self.session.get(
-            url,
-            headers={"Content-Type": "application/json", "X-Timetreea": API_USER_AGENT},
-            params={"from": PUBLIC_EVENTS_FROM},
-        )
-        if response.status_code != 200:
-            if calendar_name is not None:
-                logger.error("Failed to get events of the public calendar '%s'", calendar_name)
-            else:
-                logger.error("Failed to get events of the public calendar")
-            logger.error(response.text)
-            raise HTTPError("Failed to get public calendar events")
+        events = []
+        cursor = None
+        while True:
+            params = {"from": PUBLIC_EVENTS_FROM}
+            if cursor:
+                params["cursor"] = cursor
+            response = self.session.get(
+                url,
+                headers={"Content-Type": "application/json", "X-Timetreea": API_USER_AGENT},
+                params=params,
+            )
+            if response.status_code != 200:
+                if calendar_name is not None:
+                    logger.error("Failed to get events of the public calendar '%s'", calendar_name)
+                else:
+                    logger.error("Failed to get events of the public calendar")
+                logger.error(response.text)
+                raise HTTPError("Failed to get public calendar events")
 
-        r_json = response.json()
-        self._record_raw_response(f"public_calendar_{calendar_id}/public_events", r_json)
-        events = r_json["public_events"]
+            r_json = response.json()
+            response_name = f"public_calendar_{calendar_id}/public_events"
+            if cursor:
+                response_name = f"{response_name}_cursor_{cursor}"
+            self._record_raw_response(response_name, r_json)
+            events.extend(r_json["public_events"])
+            paging = r_json.get("paging") or {}
+            if not paging.get("next"):
+                break
+            cursor = paging.get("next_cursor")
+            if not cursor:
+                logger.error("Public events response has paging.next but no next_cursor")
+                raise HTTPError("Failed to get public calendar events")
+
         logger.info("Fetched %d public events", len(events))
         logger.debug(
             "Top 5 fetched public events: \n %s",

--- a/timetree_exporter/api/calendar.py
+++ b/timetree_exporter/api/calendar.py
@@ -138,8 +138,10 @@ class TimeTreeCalendar:
         public_calendar = r_json.get("public_calendar") or {}
         for label in public_calendar.get("public_calendar_labels", []):
             label_id = label.get("label_id")
+            if label_id is None:
+                continue
             labels[label_id] = {
-                "name": label.get("name", ""),
+                "name": str(label.get("name") or ""),
                 "color": TimeTreeCalendar._format_color(label.get("color", "")),
             }
         return labels

--- a/timetree_exporter/api/calendar.py
+++ b/timetree_exporter/api/calendar.py
@@ -112,6 +112,38 @@ class TimeTreeCalendar:
         logger.debug("Parsed %d labels: %s", len(labels), labels)
         return labels
 
+    def get_public_labels(self, calendar_id: int):
+        """
+        Get labels for a public calendar.
+        """
+        url = f"{API_V2_BASEURI}/public_calendars/{calendar_id}"
+        response = self.session.get(
+            url,
+            headers={"Content-Type": "application/json", "X-Timetreea": API_USER_AGENT},
+        )
+        if response.status_code != 200:
+            logger.error(response.text)
+            raise HTTPError("Failed to get public calendar labels")
+
+        r_json = response.json()
+        self._record_raw_response(f"public_calendar_{calendar_id}/metadata", r_json)
+        labels = self._parse_public_labels(r_json)
+        logger.debug("Parsed %d public labels: %s", len(labels), labels)
+        return labels
+
+    @staticmethod
+    def _parse_public_labels(r_json):
+        """Parse labels from a public calendar metadata response."""
+        labels = {}
+        public_calendar = r_json.get("public_calendar") or {}
+        for label in public_calendar.get("public_calendar_labels", []):
+            label_id = label.get("label_id")
+            labels[label_id] = {
+                "name": label.get("name", ""),
+                "color": TimeTreeCalendar._format_color(label.get("color", "")),
+            }
+        return labels
+
     @staticmethod
     def _format_color(color):
         """Convert a color value to hex string if it's an integer."""

--- a/timetree_exporter/api/const.py
+++ b/timetree_exporter/api/const.py
@@ -3,4 +3,5 @@ Constants for timetree_exporter
 """
 
 API_BASEURI = "https://timetreeapp.com/api/v1"
+API_V2_BASEURI = "https://timetreeapp.com/api/v2"
 API_USER_AGENT = "web/2.1.0/en"

--- a/timetree_exporter/calendar.py
+++ b/timetree_exporter/calendar.py
@@ -13,6 +13,9 @@ class CalendarApi(Protocol):
     def get_public_events(self, calendar_id, calendar_name):
         """Return events for a public calendar."""
 
+    def get_public_labels(self, calendar_id):
+        """Return labels for a public calendar."""
+
     def get_labels(self, calendar_id):
         """Return labels for a calendar."""
 
@@ -53,5 +56,5 @@ class Calendar:
     def get_labels(self):
         """Return labels for this calendar."""
         if self.is_public:
-            return {}
+            return self.api.get_public_labels(self.id)
         return self.api.get_labels(self.id)

--- a/timetree_exporter/calendar.py
+++ b/timetree_exporter/calendar.py
@@ -10,6 +10,9 @@ class CalendarApi(Protocol):
     def get_events(self, calendar_id, calendar_name):
         """Return events for a calendar."""
 
+    def get_public_events(self, calendar_id, calendar_name):
+        """Return events for a public calendar."""
+
     def get_labels(self, calendar_id):
         """Return labels for a calendar."""
 
@@ -34,12 +37,21 @@ class Calendar:
     @property
     def alias_code(self):
         """Return the calendar alias code."""
-        return self.metadata["alias_code"]
+        return self.metadata.get("alias_code")
+
+    @property
+    def is_public(self):
+        """Return whether this calendar should use the public calendar API."""
+        return self.metadata.get("public", False)
 
     def get_events(self):
         """Return events for this calendar."""
+        if self.is_public:
+            return self.api.get_public_events(self.id, self.name)
         return self.api.get_events(self.id, self.name)
 
     def get_labels(self):
         """Return labels for this calendar."""
+        if self.is_public:
+            return {}
         return self.api.get_labels(self.id)

--- a/timetree_exporter/cli.py
+++ b/timetree_exporter/cli.py
@@ -58,8 +58,13 @@ def parse_args():
         "-c",
         "--calendar_code",
         type=str,
-        help="The Calendar Code you want to export",
+        help="The Calendar Code you want to export, or public calendar id with --public-calendar",
         default=None,
+    )
+    parser.add_argument(
+        "--public-calendar",
+        help="Export a public calendar by id without signing in",
+        action="store_true",
     )
     parser.add_argument(
         "--version",

--- a/timetree_exporter/event.py
+++ b/timetree_exporter/event.py
@@ -173,7 +173,13 @@ class TimeTreePublicEvent(TimeTreeEvent):
     def from_dict(cls, event_data: dict):
         """Create TimeTreePublicEvent object from public calendar JSON data."""
         label = event_data.get("public_calendar_label") or {}
-        label_color = cls._format_color(label.get("color") or event_data.get("color"))
+        color = label.get("color")
+        if color is None:
+            color = event_data.get("color")
+        label_color = cls._format_color(color)
+        label_id = label.get("label_id")
+        if label_id is None:
+            label_id = cls._extract_label_id(event_data)
         image_urls = cls._extract_cover_image_urls(event_data)
         video_urls = cls._extract_video_urls(event_data)
         category_names = cls._extract_category_names(event_data)
@@ -197,7 +203,7 @@ class TimeTreePublicEvent(TimeTreeEvent):
             parent_id=event_data.get("parent_id"),
             event_type=event_data.get("type", TimeTreeEventType.NORMAL),
             category=event_data.get("category", TimeTreeEventCategory.NORMAL),
-            label_id=label.get("label_id") or cls._extract_label_id(event_data),
+            label_id=label_id,
             headline=event_data.get("headline"),
             overview=event_data.get("overview"),
             link_url=event_data.get("link_url"),

--- a/timetree_exporter/event.py
+++ b/timetree_exporter/event.py
@@ -95,6 +95,7 @@ class TimeTreePublicEvent(TimeTreeEvent):
     category_names: list = None
     image_urls: list = None
     video_urls: list = None
+    until_at: int = None
 
     @staticmethod
     def _extract_cover_image_urls(event_data):
@@ -208,6 +209,7 @@ class TimeTreePublicEvent(TimeTreeEvent):
             category_names=category_names,
             image_urls=image_urls,
             video_urls=video_urls,
+            until_at=event_data.get("until_at"),
         )
 
     @staticmethod

--- a/timetree_exporter/event.py
+++ b/timetree_exporter/event.py
@@ -81,6 +81,144 @@ class TimeTreeEvent:
 
 
 @dataclass
+class TimeTreePublicEvent(TimeTreeEvent):
+    """TimeTree public calendar event from the API v2 public_events response."""
+
+    headline: str = None
+    overview: str = None
+    link_url: str = None
+    location_address: str = None
+    location_url: str = None
+    location_note: str = None
+    label_name: str = None
+    label_color: str = None
+    category_names: list = None
+    image_urls: list = None
+    video_urls: list = None
+
+    @staticmethod
+    def _extract_cover_image_urls(event_data):
+        """Return public event cover image URLs."""
+        return [
+            image["url"]
+            for image in event_data.get("images", {}).get("cover", [])
+            if image.get("url")
+        ]
+
+    @staticmethod
+    def _extract_video_urls(event_data):
+        """Return public event video URLs."""
+        return [video["url"] for video in event_data.get("videos", []) if video.get("url")]
+
+    @staticmethod
+    def _build_note(event_data):
+        """Build an ICS description from public event text and links."""
+        parts = []
+        for value in (
+            event_data.get("headline"),
+            event_data.get("overview"),
+            event_data.get("note"),
+        ):
+            if value:
+                parts.append(value)
+
+        ogp = (event_data.get("attachment") or {}).get("ogp") or {}
+        if ogp.get("title"):
+            parts.append(f"Link title: {ogp['title']}")
+        if ogp.get("description"):
+            parts.append(f"Link description: {ogp['description']}")
+
+        for label, value in (
+            ("Link", event_data.get("link_url")),
+            ("Location URL", event_data.get("location_url")),
+            ("OGP URL", ogp.get("url")),
+        ):
+            if value:
+                parts.append(f"{label}: {value}")
+
+        image_urls = TimeTreePublicEvent._extract_cover_image_urls(event_data)
+        if image_urls:
+            parts.append("Images:\n" + "\n".join(image_urls))
+
+        video_urls = TimeTreePublicEvent._extract_video_urls(event_data)
+        if video_urls:
+            parts.append("Videos:\n" + "\n".join(video_urls))
+
+        return "\n\n".join(parts)
+
+    @staticmethod
+    def _build_location(event_data):
+        """Build a display location from public event location fields."""
+        return " ".join(
+            value
+            for value in (event_data.get("location_name"), event_data.get("location_address"))
+            if value
+        )
+
+    @staticmethod
+    def _extract_category_names(event_data):
+        """Return public hashtag/category names."""
+        names = []
+        for hashtag in event_data.get("public_calendar_hashtags", []):
+            if isinstance(hashtag, str):
+                names.append(hashtag)
+            elif isinstance(hashtag, dict):
+                name = hashtag.get("name") or hashtag.get("hashtag") or hashtag.get("title")
+                if name:
+                    names.append(name)
+        return names
+
+    @classmethod
+    def from_dict(cls, event_data: dict):
+        """Create TimeTreePublicEvent object from public calendar JSON data."""
+        label = event_data.get("public_calendar_label") or {}
+        label_color = cls._format_color(label.get("color") or event_data.get("color"))
+        image_urls = cls._extract_cover_image_urls(event_data)
+        video_urls = cls._extract_video_urls(event_data)
+        category_names = cls._extract_category_names(event_data)
+        return cls(
+            uuid=event_data.get("uuid") or event_data.get("id"),
+            title=event_data.get("title"),
+            created_at=event_data.get("created_at"),
+            updated_at=event_data.get("updated_at"),
+            note=cls._build_note(event_data),
+            location=event_data.get("location") or cls._build_location(event_data),
+            location_lat=event_data.get("location_lat"),
+            location_lon=event_data.get("location_lon"),
+            url=event_data.get("url"),
+            start_at=event_data.get("start_at"),
+            start_timezone=event_data.get("start_timezone"),
+            end_at=event_data.get("end_at"),
+            end_timezone=event_data.get("end_timezone"),
+            all_day=event_data.get("all_day"),
+            alerts=event_data.get("alerts"),
+            recurrences=event_data.get("recurrences"),
+            parent_id=event_data.get("parent_id"),
+            event_type=event_data.get("type", TimeTreeEventType.NORMAL),
+            category=event_data.get("category", TimeTreeEventCategory.NORMAL),
+            label_id=label.get("label_id") or cls._extract_label_id(event_data),
+            headline=event_data.get("headline"),
+            overview=event_data.get("overview"),
+            link_url=event_data.get("link_url"),
+            location_address=event_data.get("location_address"),
+            location_url=event_data.get("location_url"),
+            location_note=event_data.get("location_note"),
+            label_name=label.get("name"),
+            label_color=label_color,
+            category_names=category_names,
+            image_urls=image_urls,
+            video_urls=video_urls,
+        )
+
+    @staticmethod
+    def _format_color(color):
+        """Convert public label color to an ICS-compatible hex string."""
+        if isinstance(color, int):
+            return f"#{color:06x}"
+        return color
+
+
+@dataclass
 class TimeTreeEventType(enumerate):
     """TimeTree event type enumeration"""
 

--- a/timetree_exporter/event.py
+++ b/timetree_exporter/event.py
@@ -94,8 +94,10 @@ class TimeTreePublicEvent(TimeTreeEvent):
     label_color: str = None
     category_names: list = None
     image_urls: list = None
+    thumbnail_image_urls: list = None
     video_urls: list = None
     until_at: int = None
+    source_url: str = None
 
     @staticmethod
     def _extract_cover_image_urls(event_data):
@@ -107,6 +109,15 @@ class TimeTreePublicEvent(TimeTreeEvent):
         ]
 
     @staticmethod
+    def _extract_thumbnail_image_urls(event_data):
+        """Return public event thumbnail image URLs."""
+        return [
+            image["thumbnail_url"]
+            for image in event_data.get("images", {}).get("cover", [])
+            if image.get("thumbnail_url")
+        ]
+
+    @staticmethod
     def _extract_video_urls(event_data):
         """Return public event video URLs."""
         return [video["url"] for video in event_data.get("videos", []) if video.get("url")]
@@ -115,31 +126,9 @@ class TimeTreePublicEvent(TimeTreeEvent):
     def _build_note(event_data):
         """Build an ICS description from public event text and links."""
         parts = []
-        for value in (
-            event_data.get("headline"),
-            event_data.get("overview"),
-            event_data.get("note"),
-        ):
+        for value in (event_data.get("note"),):
             if value:
                 parts.append(value)
-
-        ogp = (event_data.get("attachment") or {}).get("ogp") or {}
-        if ogp.get("title"):
-            parts.append(f"Link title: {ogp['title']}")
-        if ogp.get("description"):
-            parts.append(f"Link description: {ogp['description']}")
-
-        for label, value in (
-            ("Link", event_data.get("link_url")),
-            ("Location URL", event_data.get("location_url")),
-            ("OGP URL", ogp.get("url")),
-        ):
-            if value:
-                parts.append(f"{label}: {value}")
-
-        image_urls = TimeTreePublicEvent._extract_cover_image_urls(event_data)
-        if image_urls:
-            parts.append("Images:\n" + "\n".join(image_urls))
 
         video_urls = TimeTreePublicEvent._extract_video_urls(event_data)
         if video_urls:
@@ -181,6 +170,7 @@ class TimeTreePublicEvent(TimeTreeEvent):
         if label_id is None:
             label_id = cls._extract_label_id(event_data)
         image_urls = cls._extract_cover_image_urls(event_data)
+        thumbnail_image_urls = cls._extract_thumbnail_image_urls(event_data)
         video_urls = cls._extract_video_urls(event_data)
         category_names = cls._extract_category_names(event_data)
         return cls(
@@ -192,7 +182,7 @@ class TimeTreePublicEvent(TimeTreeEvent):
             location=event_data.get("location") or cls._build_location(event_data),
             location_lat=event_data.get("location_lat"),
             location_lon=event_data.get("location_lon"),
-            url=event_data.get("url"),
+            url=event_data.get("link_url"),
             start_at=event_data.get("start_at"),
             start_timezone=event_data.get("start_timezone"),
             end_at=event_data.get("end_at"),
@@ -214,8 +204,10 @@ class TimeTreePublicEvent(TimeTreeEvent):
             label_color=label_color,
             category_names=category_names,
             image_urls=image_urls,
+            thumbnail_image_urls=thumbnail_image_urls,
             video_urls=video_urls,
             until_at=event_data.get("until_at"),
+            source_url=event_data.get("url"),
         )
 
     @staticmethod

--- a/timetree_exporter/exporter.py
+++ b/timetree_exporter/exporter.py
@@ -83,7 +83,7 @@ def public_labels_from_events(events):
         if color is None:
             color = event.get("color", "")
         labels[label_id] = {
-            "name": label.get("name", ""),
+            "name": str(label.get("name") or ""),
             "color": f"#{color:06x}" if isinstance(color, int) else color,
         }
     return labels

--- a/timetree_exporter/exporter.py
+++ b/timetree_exporter/exporter.py
@@ -79,8 +79,8 @@ def public_labels_from_events(events):
         label_id = label.get("label_id")
         if label_id is None:
             continue
-        color = label.get("color", "")
-        if not color:
+        color = label.get("color")
+        if color is None:
             color = event.get("color", "")
         labels[label_id] = {
             "name": label.get("name", ""),

--- a/timetree_exporter/exporter.py
+++ b/timetree_exporter/exporter.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from icalendar import Calendar as ICalendar
 
-from timetree_exporter import ICalEventFormatter, TimeTreeEvent
+from timetree_exporter import ICalEventFormatter, TimeTreeEvent, TimeTreePublicEvent
 from timetree_exporter.utils import add_bounded_timezones_before_events
 
 logger = logging.getLogger(__name__)
@@ -28,14 +28,18 @@ class Exporter:
         logger.info("Found %d events", len(events))
 
         labels = self.calendar.get_labels()
+        if self.calendar.is_public and not labels:
+            labels = public_labels_from_events(events)
         logger.info("Found %d labels", len(labels))
 
+        event_cls = TimeTreePublicEvent if self.calendar.is_public else TimeTreeEvent
+
         if self.split_by_label:
-            grouped_events = group_events_by_label(events, labels)
+            grouped_events = group_events_by_label(events, labels, event_cls=event_cls)
             write_split_calendars(grouped_events, labels, self.output, len(events))
             return
 
-        cal = build_single_calendar(events, labels)
+        cal = build_single_calendar(events, labels, event_cls=event_cls)
         logger.info(
             "A total of %d/%d events are added to the calendar",
             len(cal.subcomponents),
@@ -67,17 +71,44 @@ def write_calendar(cal, output_path: str | Path):
         logger.info("The .ics calendar file is saved to %s", path.resolve())
 
 
-def build_single_calendar(events, labels):
+def public_labels_from_events(events):
+    """Build label metadata from public calendar event payloads."""
+    labels = {}
+    for event in events:
+        label = event.get("public_calendar_label") or {}
+        label_id = label.get("label_id")
+        if label_id is None:
+            continue
+        color = label.get("color", "")
+        if not color:
+            color = event.get("color", "")
+        labels[label_id] = {
+            "name": label.get("name", ""),
+            "color": f"#{color:06x}" if isinstance(color, int) else color,
+        }
+    return labels
+
+
+def build_single_calendar(events, labels, event_cls=TimeTreeEvent):
     """Build single output calendar from events."""
     cal = create_calendar()
     label_lookup = {lid: info["name"] for lid, info in labels.items()} if labels else {}
     color_lookup = {lid: info["color"] for lid, info in labels.items()} if labels else {}
 
     for event in events:
-        time_tree_event = TimeTreeEvent.from_dict(event)
-        label_name = label_lookup.get(time_tree_event.label_id)
-        color = color_lookup.get(time_tree_event.label_id)
-        formatter = ICalEventFormatter(time_tree_event, label_name=label_name, color=color)
+        time_tree_event = event_cls.from_dict(event)
+        label_name = label_lookup.get(time_tree_event.label_id) or getattr(
+            time_tree_event, "label_name", None
+        )
+        color = color_lookup.get(time_tree_event.label_id) or getattr(
+            time_tree_event, "label_color", None
+        )
+        formatter = ICalEventFormatter(
+            time_tree_event,
+            label_name=label_name,
+            color=color,
+            category_names=getattr(time_tree_event, "category_names", None),
+        )
         ical_event = formatter.to_ical()
         if ical_event is not None:
             cal.add_component(ical_event)
@@ -85,22 +116,31 @@ def build_single_calendar(events, labels):
     return cal
 
 
-def group_events_by_label(events, labels):
+def group_events_by_label(events, labels, event_cls=TimeTreeEvent):
     """Group converted iCal events by label id (or None for unlabeled)."""
     grouped = defaultdict(list)
 
     for event in events:
-        time_tree_event = TimeTreeEvent.from_dict(event)
+        time_tree_event = event_cls.from_dict(event)
         label_info = labels.get(time_tree_event.label_id)
-        label_name = label_info["name"] if label_info is not None else None
-        color = label_info["color"] if label_info is not None else None
-        formatter = ICalEventFormatter(time_tree_event, label_name=label_name, color=color)
+        if label_info is not None:
+            label_name = label_info["name"]
+            color = label_info["color"]
+        else:
+            label_name = getattr(time_tree_event, "label_name", None)
+            color = getattr(time_tree_event, "label_color", None)
+        formatter = ICalEventFormatter(
+            time_tree_event,
+            label_name=label_name,
+            color=color,
+            category_names=getattr(time_tree_event, "category_names", None),
+        )
         ical_event = formatter.to_ical()
 
         if ical_event is None:
             continue
 
-        group_key = time_tree_event.label_id if label_info is not None else None
+        group_key = time_tree_event.label_id if label_name or color else None
         grouped[group_key].append(ical_event)
 
     return grouped

--- a/timetree_exporter/formatter.py
+++ b/timetree_exporter/formatter.py
@@ -26,10 +26,17 @@ class ICalEventFormatter:
     Class for formatting TimeTree events into iCalendar format.
     """
 
-    def __init__(self, time_tree_event: TimeTreeEvent, label_name: str = None, color: str = None):
+    def __init__(
+        self,
+        time_tree_event: TimeTreeEvent,
+        label_name: str = None,
+        color: str = None,
+        category_names: list = None,
+    ):
         self.time_tree_event = time_tree_event
         self.label_name = label_name
         self._color = color
+        self.category_names = category_names or []
 
     @property
     def color(self):
@@ -58,8 +65,12 @@ class ICalEventFormatter:
 
     @property
     def categories(self):
-        """Return the label name as CATEGORIES."""
-        return self.label_name
+        """Return label and public hashtag names as CATEGORIES."""
+        categories = []
+        if self.label_name:
+            categories.append(self.label_name)
+        categories.extend(self.category_names)
+        return categories or None
 
     @property
     def uid(self):
@@ -246,7 +257,7 @@ class ICalEventFormatter:
         if self.related_to:
             event.add("related-to", self.related_to)
         if self.categories:
-            event.add("categories", [self.categories])
+            event.add("categories", self.categories)
         if self.color:
             event.add("color", self.color)
 

--- a/timetree_exporter/formatter.py
+++ b/timetree_exporter/formatter.py
@@ -107,6 +107,11 @@ class ICalEventFormatter:
         return self.time_tree_event.location if self.time_tree_event.location != "" else None
 
     @property
+    def location_altrep(self):
+        """Return an alternate representation URI for the location."""
+        return getattr(self.time_tree_event, "location_url", None)
+
+    @property
     def geo(self):
         """Return the geolocation of the event."""
         if self.time_tree_event.location_lat is None or self.time_tree_event.location_lon is None:
@@ -117,6 +122,21 @@ class ICalEventFormatter:
     def url(self):
         """Return the URL of the event."""
         return self.time_tree_event.url if self.time_tree_event.url != "" else None
+
+    @property
+    def source(self):
+        """Return the source URL of the event."""
+        return getattr(self.time_tree_event, "source_url", None)
+
+    @property
+    def images(self):
+        """Return image URLs for the event."""
+        return getattr(self.time_tree_event, "image_urls", None) or []
+
+    @property
+    def thumbnail_images(self):
+        """Return thumbnail image URLs for the event."""
+        return getattr(self.time_tree_event, "thumbnail_image_urls", None) or []
 
     @property
     def related_to(self):
@@ -261,11 +281,18 @@ class ICalEventFormatter:
         event.add("dtend", self.dtend)
 
         if self.location:
-            event.add("location", self.location)
+            params = {"ALTREP": self.location_altrep} if self.location_altrep else {}
+            event.add("location", self.location, parameters=params)
         if self.geo:
             event.add("geo", self.geo)
         if self.url:
             event.add("url", self.url)
+        if self.source:
+            event.add("source", self.source, parameters={"VALUE": "URI"})
+        for image_url in self.images:
+            event.add("image", image_url, parameters={"VALUE": "URI", "DISPLAY": "FULLSIZE"})
+        for image_url in self.thumbnail_images:
+            event.add("image", image_url, parameters={"VALUE": "URI", "DISPLAY": "THUMBNAIL"})
         if self.description:
             event.add("description", self.description)
         if self.related_to:

--- a/timetree_exporter/formatter.py
+++ b/timetree_exporter/formatter.py
@@ -195,12 +195,26 @@ class ICalEventFormatter:
                         ZoneInfo(self.time_tree_event.start_timezone),
                     )
                     recurrence_rule["UNTIL"] = [local_until.astimezone(ZoneInfo("UTC"))]
+                elif not until and getattr(self.time_tree_event, "until_at", None):
+                    recurrence_rule["UNTIL"] = [self.recurrence_until]
                 event.add(name, recurrence_rule, parameters)
             elif name.lower() == "exdate" or name.lower() == "rdate":
                 event.add(name, vDDDLists.from_ical(value), parameters)
             else:
                 logger.error("Unknown recurrence type: %s", name)
                 raise ValueError(f"Unknown recurrence type: {name}")
+
+    @property
+    def recurrence_until(self):
+        """Return public recurrence end from until_at."""
+        until = convert_timestamp_to_datetime(
+            self.time_tree_event.until_at / 1000,
+            ZoneInfo("UTC"),
+        )
+        if self.time_tree_event.all_day:
+            timezone = self.time_tree_event.end_timezone or self.time_tree_event.start_timezone
+            return until.astimezone(ZoneInfo(timezone)).date()
+        return until
 
     def to_ical(self) -> Event:
         """Return the iCal event."""

--- a/timetree_exporter/formatter.py
+++ b/timetree_exporter/formatter.py
@@ -203,6 +203,9 @@ class ICalEventFormatter:
             if name.lower() == "rrule":
                 recurrence_rule = vRecur.from_ical(value)
                 until = recurrence_rule.get("UNTIL")
+                if "COUNT" in recurrence_rule and until:
+                    logger.error("RRULE must not include both COUNT and UNTIL: %s", recurrence)
+                    raise ValueError("RRULE must not include both COUNT and UNTIL")
                 if (
                     until
                     and not self.time_tree_event.all_day
@@ -215,26 +218,12 @@ class ICalEventFormatter:
                         ZoneInfo(self.time_tree_event.start_timezone),
                     )
                     recurrence_rule["UNTIL"] = [local_until.astimezone(ZoneInfo("UTC"))]
-                elif not until and getattr(self.time_tree_event, "until_at", None) is not None:
-                    recurrence_rule["UNTIL"] = [self.recurrence_until]
                 event.add(name, recurrence_rule, parameters)
             elif name.lower() == "exdate" or name.lower() == "rdate":
                 event.add(name, vDDDLists.from_ical(value), parameters)
             else:
                 logger.error("Unknown recurrence type: %s", name)
                 raise ValueError(f"Unknown recurrence type: {name}")
-
-    @property
-    def recurrence_until(self):
-        """Return public recurrence end from until_at."""
-        until = convert_timestamp_to_datetime(
-            self.time_tree_event.until_at / 1000,
-            ZoneInfo("UTC"),
-        )
-        if self.time_tree_event.all_day:
-            timezone = self.time_tree_event.end_timezone or self.time_tree_event.start_timezone
-            return until.astimezone(ZoneInfo(timezone)).date()
-        return until
 
     def to_ical(self) -> Event:
         """Return the iCal event."""

--- a/timetree_exporter/formatter.py
+++ b/timetree_exporter/formatter.py
@@ -215,7 +215,7 @@ class ICalEventFormatter:
                         ZoneInfo(self.time_tree_event.start_timezone),
                     )
                     recurrence_rule["UNTIL"] = [local_until.astimezone(ZoneInfo("UTC"))]
-                elif not until and getattr(self.time_tree_event, "until_at", None):
+                elif not until and getattr(self.time_tree_event, "until_at", None) is not None:
                     recurrence_rule["UNTIL"] = [self.recurrence_until]
                 event.add(name, recurrence_rule, parameters)
             elif name.lower() == "exdate" or name.lower() == "rdate":


### PR DESCRIPTION
**Summary**
Adds support for exporting TimeTree public calendars via the public API v2 endpoint.

Closes #57.

**Changes**
- Added `--public-calendar` CLI option.
- Public calendars use `-c/--calendar_code` as the public calendar id and skip login.
- Fetches public events from `/api/v2/public_calendars/{calendar_id}/public_events`.
- Uses `from=0` to avoid TimeTree's short default event window.
- Follows public event pagination with `paging.next` and `paging.next_cursor`.
- Added `TimeTreePublicEvent` for public API v2 event normalization.
- Reads public labels from public calendar metadata for `--public-calendar --list-labels`.
- Keeps event-label synthesis as an export fallback.
- Updated README and DEVELOPMENT notes, including RFC 5545/RFC 7986 compatibility guidance.
- Added regression tests for public event export, pagination, labels, categories, colors, recurrence handling, source links, alternate location URLs, and images.

**Compatibility**
- The generated `.ics` output remains based on RFC 5545 iCalendar.
- Public calendar metadata uses selected RFC 7986 properties where available, including `SOURCE`, `IMAGE`, and `COLOR`.
- Calendar apps that only implement RFC 5545 may ignore those optional RFC 7986 fields.
- Unbounded public `RRULE`s are preserved because RFC 5545 allows recurring events without `COUNT` or `UNTIL`.
- Invalid upstream `RRULE`s containing both `COUNT` and `UNTIL` fail loudly instead of being silently rewritten.

**Public Event ICS Mapping**
- `id` -> `UID`
- `title` -> `SUMMARY`
- `note` -> `DESCRIPTION`
- `link_url` -> `URL`
- TimeTree public permalink `url` -> `SOURCE;VALUE=URI`
- `location_name` / `location_address` -> `LOCATION`
- `location_url` -> `LOCATION;ALTREP`
- `location_lat` / `location_lon` -> `GEO`
- `public_calendar_label.name` and hashtags -> `CATEGORIES`
- `public_calendar_label.color` or top-level `color` -> `COLOR`
- cover image URL -> `IMAGE;VALUE=URI;DISPLAY=FULLSIZE`
- cover thumbnail URL -> `IMAGE;VALUE=URI;DISPLAY=THUMBNAIL`
- video URLs -> appended to `DESCRIPTION`

**Intentional Non-Mappings**
- Public OGP fields are ignored to avoid duplicating `URL`, `SUMMARY`, or `DESCRIPTION`.
- Public `headline` and `overview` are ignored because observed public calendars keep event details in `note`.
- Public `until_at` is ignored because it appears on one-off events and can represent a broad TimeTree horizon rather than an explicit recurrence end.
- TimeTree public permalink `url` is not used as ICS `URL`; it is exported as `SOURCE` instead.